### PR TITLE
chore(ci): Deploy to Staging を手動実行のみに変更

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -1,8 +1,6 @@
 name: Deploy to Staging
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 概要

AWS 認証情報（Secrets）が未設定の段階で、`Deploy to Staging` ワークフローが `main` への push のたびに自動実行され、毎回失敗していました。
これにより GitHub の CI ステータスが常に失敗表示になっていたため、トリガーを `workflow_dispatch`（手動実行）のみに変更します。

## 変更内容

- `.github/workflows/deploy-stg.yml` から `push: branches: [main]` トリガーを削除
- `workflow_dispatch`（手動実行）は維持

## 今後の対応

AWS のセットアップ（OIDC / Secrets 設定）完了後に `push` トリガーを再追加してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)