### PR TITLE
feat(bootstrap): labels bootstrap + capability detection (#24)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -39,8 +39,12 @@ docdd-starters/
 │       └── src/           # 共通モジュール
 ├── docs/
 │   ├── 7-axis/            # DocDD 7軸トレーサビリティ文書
+│   ├── guides/            # セットアップ・運用ガイド（bootstrap 等）
 │   └── testing/           # テスト管理・トレーサビリティmap
 ├── scripts/
+│   ├── bootstrap.sh       # fork 直後の bootstrap wrapper（preflight 統括）
+│   ├── claude/            # capability 検出など Claude 関連スクリプト
+│   ├── github/            # gh CLI を使うラベル/Issue 管理スクリプト
 │   ├── test/              # トレーサビリティ検証スクリプト
 │   ├── frontend/          # フロントエンド用スクリプト
 │   └── deploy/            # デプロイスクリプト（Terraform / ECS）
@@ -50,7 +54,8 @@ docdd-starters/
 ├── .claude/
 │   ├── commands/          # カスタムスラッシュコマンド
 │   ├── skills/            # AI実行知識（ドメイン・パターン）
-│   └── rules/             # モジュール化ルール（命名・規約）
+│   ├── rules/             # モジュール化ルール（命名・規約）
+│   └── references/        # コマンド/スキルから参照する静的ドキュメント
 └── README.md
 ```
 

--- a/.claude/references/README.md
+++ b/.claude/references/README.md
@@ -1,0 +1,13 @@
+# References
+
+Claude Code のコマンド / スキルから参照される静的ドキュメント置き場です。
+
+| ドキュメント | 用途 |
+|-------------|------|
+| [capability-matrix.md](./capability-matrix.md) | Epic #23 の Phase 0-F × capability 対応表。`scripts/claude/detect-capabilities.sh` の出力を consumer 側がどう扱うかを定義 |
+
+## 関連ファイル
+
+- [../../scripts/claude/detect-capabilities.sh](../../scripts/claude/detect-capabilities.sh) - capability 検出スクリプト
+- [../../scripts/bootstrap.sh](../../scripts/bootstrap.sh) - bootstrap wrapper
+- [../../docs/guides/bootstrap.md](../../docs/guides/bootstrap.md) - fork 直後のセットアップ手順

--- a/.claude/references/capability-matrix.md
+++ b/.claude/references/capability-matrix.md
@@ -1,0 +1,87 @@
+# Capability Matrix (Phase 0-F × Issue)
+
+Epic #23 の全 21 Issue について、必要な capability と fallback 挙動をまとめます。
+
+- `Required` は [`scripts/claude/detect-capabilities.sh`](../../scripts/claude/detect-capabilities.sh) が出力する capability 名で記述
+- `Fallback` は capability が `unavailable` / `unknown` だった場合の consumer 側の期待挙動
+- 本 Issue (#24) の時点では **契約定義のみ**。consumer 側の実装は Phase 1 Issue 1-1 以降で順次接続されます（ADR-05）
+
+## Phase 0 — Bootstrap & capability detection
+
+| Issue | Track | Required | Fallback | Notes |
+|:-----:|:-----:|----------|----------|-------|
+| 0-1 | Core | `gh_installed`, `jq`, `git` | preflight で error out（明確なエラーメッセージで停止） | 本 Issue |
+| 0-2 | Core | `gh_authenticated` | `gh auth login` を案内して停止 | Phase 0 preflight 拡張 |
+
+## Phase 1 — Core automation
+
+| Issue | Track | Required | Fallback | Notes |
+|:-----:|:-----:|----------|----------|-------|
+| 1-1 | Core | `gh_authenticated`, `repo_write_access` | capability 参照実装の初出 | consumer 接続の最初 |
+| 1-2 | Core | — | `make shell-lint` 用 shellcheck 統合 | shellcheck 未導入環境は skip + warn |
+| 1-3 | Core | `projects_api_available` | `unknown`/`unavailable` なら Projects 連携を skip、Issue ラベルのみで代替 | GitHub Projects 連携 |
+| 1-4 | Core | `codex_cli` | `unavailable` なら Codex レビューステップを skip + warn | `/2` のエージェントレビュー |
+| 1-5 | Core | `gh_authenticated` | `unavailable` なら PR コマンドを停止 | `/6` PR 作成 |
+
+## Phase 2 — Canonicalization
+
+| Issue | Track | Required | Fallback | Notes |
+|:-----:|:-----:|----------|----------|-------|
+| 2-1 | Core | `.github/labels.json` | `legacy_alias_map` を使って既存日本語ラベルを canonical 英語ラベルへ機械的に移行 | `/1` / `/2` の canonical 化 |
+| 2-2 | Core | `gh_authenticated` | unavailable で停止 | Issue template 整備 |
+| 2-3 | Core | — | rules 更新のみ | commit-messages / branch-naming の英語化 |
+
+## Phase 3 — Traceability automation
+
+| Issue | Track | Required | Fallback | Notes |
+|:-----:|:-----:|----------|----------|-------|
+| 3-1 | Core | — | 静的スクリプトのみ | `validate_traceability_map.py` 拡張 |
+| 3-2 | Core | — | 静的スクリプトのみ | 7-axis frontmatter lint |
+| 3-3 | Core | `gh_authenticated` | PR コメント fallback（失敗時 warn） | CI への統合 |
+
+## Phase 4 — Agent teams
+
+| Issue | Track | Required | Fallback | Notes |
+|:-----:|:-----:|----------|----------|-------|
+| 4-1 | Core | `codex_cli` | `unavailable` なら単独 Claude 実行に退避 | `/5` verify quality-gate |
+| 4-2 | Core | — | ロール定義のみ | agent-teams rules 拡張 |
+
+## Optional A — Pencil design integration
+
+| Issue | Track | Required | Fallback | Notes |
+|:-----:|:-----:|----------|----------|-------|
+| A-1 | Optional | `mcp_servers`, `pencil_mcp` | `unavailable` なら design スキルを doc-only で動作 | Pencil MCP 未設定でも可 |
+| A-2 | Optional | `pencil_mcp` | unavailable で skip | `/2` で Pencil 差分チェック |
+
+## Optional B — Computer Use automation
+
+| Issue | Track | Required | Fallback | Notes |
+|:-----:|:-----:|----------|----------|-------|
+| B-1 | Optional | `computer_use` | `unavailable` なら UI 検証を手動に案内 | `/4` の UI 確認自動化 |
+| B-2 | Optional | `computer_use` | 同上 | `/5` の UI 検証自動化 |
+
+## Optional C — MCP ecosystem extensions
+
+| Issue | Track | Required | Fallback | Notes |
+|:-----:|:-----:|----------|----------|-------|
+| C-1 | Optional | `mcp_servers` | doc-only（未設定でも可） | Gmail / Calendar / Notion 連携ガイド |
+| C-2 | Optional | `mcp_servers` | 同上 | 追加 MCP server の onboarding テンプレ |
+
+## Phase F — Finalization
+
+| Issue | Track | Required | Fallback | Notes |
+|:-----:|:-----:|----------|----------|-------|
+| F-1 | Core | 全 capability | 全 Fallback 経路を `make bootstrap` → `/1` シナリオで E2E 検証 | リリース前最終チェック |
+
+## 凡例
+
+- **Core**: fork 直後の最短経路で必要な機能
+- **Optional**: 外部ツール連携で強化される機能。未導入でも Core パスは成立する
+- **Fallback**: `state` が `unavailable` または `unknown` の場合の consumer 側の期待挙動
+
+## 関連リンク
+
+- [scripts/claude/detect-capabilities.sh](../../scripts/claude/detect-capabilities.sh)
+- [scripts/bootstrap.sh](../../scripts/bootstrap.sh)
+- [docs/guides/bootstrap.md](../../docs/guides/bootstrap.md)
+- [.github/labels.json](../../.github/labels.json)

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "managed_labels": [
+    { "name": "P0", "color": "B60205", "description": "Priority: critical (canonical). Legacy alias: High" },
+    { "name": "P1", "color": "FBCA04", "description": "Priority: high (canonical). Legacy alias: Medium" },
+    { "name": "P2", "color": "0E8A16", "description": "Priority: normal (canonical). Legacy alias: Low" },
+    { "name": "BE", "color": "1D76DB", "description": "Area: backend (canonical). Legacy alias: バックエンド" },
+    { "name": "FE", "color": "5319E7", "description": "Area: frontend (canonical). Legacy alias: フロントエンド" },
+    { "name": "infra", "color": "006B75", "description": "Area: infrastructure (canonical). Legacy alias: インフラ" },
+    { "name": "status:todo", "color": "CFD3D7", "description": "Status: not started" },
+    { "name": "status:in-progress", "color": "FBCA04", "description": "Status: in progress" },
+    { "name": "status:done", "color": "0E8A16", "description": "Status: completed" },
+    { "name": "docs", "color": "0075CA", "description": "Kind: documentation (canonical). Legacy alias: ドキュメント" },
+    { "name": "tests", "color": "D4C5F9", "description": "Kind: tests (canonical). Legacy alias: テスト" },
+    { "name": "chore", "color": "CFD3D7", "description": "Kind: chores (build, deps, meta)" },
+    { "name": "bug", "color": "d73a4a", "description": "Kind: bug (canonical). Legacy alias: バグ" },
+    { "name": "High", "color": "B60205", "description": "優先度: 高 (legacy). Canonical: P0" },
+    { "name": "Medium", "color": "FBCA04", "description": "優先度: 中 (legacy). Canonical: P1" },
+    { "name": "Low", "color": "0E8A16", "description": "優先度: 低 (legacy). Canonical: P2" },
+    { "name": "バックエンド", "color": "1D76DB", "description": "バックエンド関連 (legacy). Canonical: BE" },
+    { "name": "フロントエンド", "color": "5319E7", "description": "フロントエンド関連 (legacy). Canonical: FE" },
+    { "name": "インフラ", "color": "006B75", "description": "インフラ・CI/CD関連 (legacy). Canonical: infra" },
+    { "name": "ドキュメント", "color": "0075CA", "description": "ドキュメント関連 (legacy). Canonical: docs" },
+    { "name": "テスト", "color": "D4C5F9", "description": "テスト関連 (legacy). Canonical: tests" },
+    { "name": "バグ", "color": "d73a4a", "description": "不具合 (legacy). Canonical: bug" }
+  ],
+  "legacy_alias_map": {
+    "High": "P0",
+    "Medium": "P1",
+    "Low": "P2",
+    "バックエンド": "BE",
+    "フロントエンド": "FE",
+    "インフラ": "infra",
+    "ドキュメント": "docs",
+    "テスト": "tests",
+    "バグ": "bug"
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 .PHONY: up down backend-shell test test-backend test-frontend traceability install install-dev
+.PHONY: bootstrap
 .PHONY: tf-init tf-plan tf-apply tf-destroy tf-output
 .PHONY: deploy-backend-stg deploy-frontend-stg deploy-stg deploy-backend-prod deploy-frontend-prod deploy-prod
 .PHONY: ecs-status ecs-logs-backend ecs-logs-frontend ecs-sh
+
+# ─── Bootstrap ───────────────────────────────────────────
+
+bootstrap:
+	@./scripts/bootstrap.sh
 
 # ─── Local Development ───────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ tests/                  # バックエンド・フロントエンドテスト
 
 | カテゴリ | リンク |
 |---------|--------|
+| Bootstrap ガイド | [docs/guides/bootstrap.md](docs/guides/bootstrap.md) |
 | 7-axis テンプレート | [docs/7-axis](docs/7-axis) |
 | バックエンドガイド | [docs/backend/README.md](docs/backend/README.md) |
 | フロントエンドガイド | [docs/frontend/README.md](docs/frontend/README.md) |

--- a/docs/guides/bootstrap.md
+++ b/docs/guides/bootstrap.md
@@ -1,0 +1,139 @@
+# Bootstrap Guide
+
+fork 直後のユーザーが最初の `/1` を実行するまでに必要なセットアップをまとめます。
+
+## 対応 OS
+
+| OS | サポート |
+|----|:--------:|
+| macOS | ✅ |
+| Linux | ✅ |
+| WSL (Windows Subsystem for Linux) | ✅ |
+| Pure Windows (PowerShell / cmd) | ❌ |
+
+Pure Windows 環境は非対応です。WSL を利用してください。
+
+## 前提ツール
+
+| ツール | 用途 | インストール例 |
+|-------|------|---------------|
+| `git` | バージョン管理 | プラットフォーム標準 |
+| `gh` (GitHub CLI) | Issue / Label / Projects 操作 | <https://cli.github.com/> |
+| `jq` | JSON 処理 | `brew install jq` / `apt install jq` |
+
+`gh auth status` が成功する状態にしておく必要があります。
+
+## 手順
+
+```bash
+# 1. fork したリポジトリを clone
+git clone https://github.com/<your-account>/docdd-starters.git
+cd docdd-starters
+
+# 2. GitHub にログイン
+gh auth login
+
+# 3. bootstrap を実行
+make bootstrap
+```
+
+`make bootstrap` は以下を実行します:
+
+1. **preflight**: `gh` / `jq` / `git` / `gh auth` / `origin` fork / `labels.json` の構文をチェック
+2. **capability 検出**: `scripts/claude/detect-capabilities.sh` を実行し、結果を `/tmp/docdd-capabilities.json` に保存（stderr に pretty-print）
+3. **ラベル収束**: `.github/labels.json` に定義された 22 ラベル（canonical 英語 13 + 日本語互換 9）を `gh label create --force` で作成 / 更新
+
+2 回連続で実行しても repo 配下に untracked file は作成されません（`git status --porcelain` が空のまま）。
+
+## Capability JSON の読み方
+
+`/tmp/docdd-capabilities.json` は schema v1 準拠の JSON です。各 capability の `state` は 3 値:
+
+| state | 意味 | consumer 側の扱い |
+|-------|------|------------------|
+| `available` | 検出成功・利用可能 | 通常通り利用 |
+| `unavailable` | 明示的に未導入 | gracefully skip、warning |
+| `unknown` | 判定不能（scope 不足・検出手段なし） | skip + 再確認を促す |
+
+`owner_projects_count.value` は **観測値** です（設定値ではない点に注意）。`gh project list --owner <login> --limit 200` で取得しているため、200 を超える projects がある環境では最大 200 で頭打ちになります。
+
+### 主要 capability
+
+| capability | 説明 |
+|-----------|------|
+| `gh_installed` | `command -v gh` |
+| `gh_authenticated` | `gh auth status` |
+| `repo_write_access` | `gh api repos/:owner/:repo -q .permissions.push` |
+| `projects_api_available` | `gh project list --owner :login --limit 200 --format json` |
+| `owner_projects_count` | 上記レスポンスの `.projects | length`（観測上限 200） |
+| `codex_cli` | `command -v codex && codex --version` |
+| `mcp_servers` | `.claude/settings.json` / `.claude/settings.local.json` / `~/.claude.json` |
+| `pencil_mcp` | `mcp_servers` の name に `pencil` を含むか |
+| `computer_use` | 設定ファイル内に `computer-use` 系の定義があるか |
+
+## トラブルシュート
+
+### `gh CLI が見つかりません`
+
+<https://cli.github.com/> から gh をインストールしてください。
+
+### `jq が見つかりません`
+
+```bash
+brew install jq        # macOS
+sudo apt install jq    # Debian/Ubuntu
+```
+
+### `gh auth login を実行して GitHub にログインしてください`
+
+```bash
+gh auth login
+```
+
+### `origin owner ... が gh ログインユーザー ... と一致しません`
+
+`origin` が upstream を指している可能性があります:
+
+```bash
+git remote -v
+git remote set-url origin https://github.com/<your-account>/docdd-starters.git
+```
+
+意図しない repository に label を書き込む事故を防ぐため、一致しない場合は bootstrap を中断します。
+
+### Projects が未作成
+
+bootstrap は Projects の自動作成を行いません。利用する場合は GitHub Web UI で作成してください。Projects が無くても bootstrap は成功します（`projects_api_available.state` が `unknown` または `unavailable` になるだけ）。
+
+### ラベルが作成されたか確認したい
+
+```bash
+gh label list -L 200
+```
+
+`.github/labels.json` の `managed_labels` 全件と、既存ラベル（`bug`, `documentation` 等 GitHub デフォルト分）が並んで表示されれば成功です。
+
+### デバッグ出力を見たい
+
+`make bootstrap` の stdout は空です。ログ / JSON は stderr に出ます:
+
+```bash
+make bootstrap 2>&1 | less
+```
+
+## 次のステップ
+
+bootstrap 完了後は、以下の流れで開発を開始できます:
+
+```bash
+# Issue 作成（Claude Code スラッシュコマンド）
+/1
+
+# 計画立案
+/2 <issue-number>
+
+# ブランチ作成
+/3 <issue-number>
+```
+
+詳細は [.claude/commands/README.md](../../.claude/commands/README.md) を参照してください。

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# scripts/bootstrap.sh
+#
+# DocDD starters bootstrap wrapper.
+# Runs preflight checks, then delegates to capability detection and label
+# bootstrap. All logs and JSON pretty-print go to stderr; stdout is empty.
+#
+# Depth note: this script lives at `scripts/` (depth 1), so REPO_ROOT is one
+# directory up. Sibling scripts under `scripts/github/` or `scripts/claude/`
+# (depth 2) must use `$SCRIPT_DIR/../..` instead. See ADR-06 in the Issue #24
+# implementation plan.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+log() { printf '%s\n' "$*" >&2; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# ─── Preflight ───────────────────────────────────────────
+
+command -v gh  >/dev/null 2>&1 || die "gh CLI が見つかりません。https://cli.github.com/ からインストールしてください"
+command -v jq  >/dev/null 2>&1 || die "jq が見つかりません。\`brew install jq\` または \`apt install jq\` を実行してください"
+command -v git >/dev/null 2>&1 || die "git が見つかりません。git をインストールしてください"
+
+if ! gh auth status >/dev/null 2>&1; then
+  die "gh auth login を実行して GitHub にログインしてください"
+fi
+
+LABELS_JSON="$REPO_ROOT/.github/labels.json"
+[ -f "$LABELS_JSON" ] || die ".github/labels.json が見つかりません: $LABELS_JSON"
+
+# origin が自分の fork を指すか検証
+origin_url=""
+if ! origin_url=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null); then
+  die "git remote 'origin' が設定されていません。\`git remote add origin <fork-url>\` を実行してください"
+fi
+
+# HTTPS / SSH いずれの形式も owner を抽出
+origin_owner=""
+case "$origin_url" in
+  https://github.com/*)
+    rest="${origin_url#https://github.com/}"
+    origin_owner="${rest%%/*}"
+    ;;
+  git@github.com:*)
+    rest="${origin_url#git@github.com:}"
+    origin_owner="${rest%%/*}"
+    ;;
+  ssh://git@github.com/*)
+    rest="${origin_url#ssh://git@github.com/}"
+    origin_owner="${rest%%/*}"
+    ;;
+  *)
+    die "origin URL の形式を認識できません: $origin_url"
+    ;;
+esac
+
+gh_login=""
+gh_login=$(gh api user -q .login 2>/dev/null) || die "gh api user が失敗しました。scope を確認してください"
+
+if [ "$origin_owner" != "$gh_login" ]; then
+  die "origin owner ($origin_owner) が gh ログインユーザー ($gh_login) と一致しません。意図しない repo への label 変更を防ぐため停止します。\`git remote set-url origin <your-fork-url>\` を実行してください"
+fi
+
+# labels.json 構文検証
+jq -e '.version == 1 and (.managed_labels | type == "array") and (.managed_labels | length > 0)' \
+  "$LABELS_JSON" >/dev/null || die ".github/labels.json の構文が不正です (version != 1 または managed_labels 空)"
+
+# legacy_alias_map の各 value が managed_labels に存在するか検証
+missing=$(jq -r '
+  .managed_labels as $m
+  | (.legacy_alias_map // {})
+  | to_entries[]
+  | select((.value as $v | ($m | map(.name) | index($v))) | not)
+  | "\(.key) -> \(.value)"
+' "$LABELS_JSON")
+if [ -n "$missing" ]; then
+  die "legacy_alias_map の target が managed_labels に存在しません:"$'\n'"$missing"
+fi
+
+# managed_labels の name 重複検出
+duplicates=$(jq -r '.managed_labels | group_by(.name) | map(select(length > 1) | .[0].name) | .[]' "$LABELS_JSON")
+if [ -n "$duplicates" ]; then
+  die "managed_labels に重複する name が存在します:"$'\n'"$duplicates"
+fi
+
+log "preflight OK (owner=$gh_login, labels=$(jq '.managed_labels | length' "$LABELS_JSON"))"
+
+# ─── Execute phases ──────────────────────────────────────
+
+CAPABILITY_FILE="${DOCDD_CAPABILITY_FILE:-/tmp/docdd-capabilities.json}"
+
+"$REPO_ROOT/scripts/claude/detect-capabilities.sh" > "$CAPABILITY_FILE"
+
+log "=== capabilities ==="
+jq . "$CAPABILITY_FILE" >&2
+
+"$REPO_ROOT/scripts/github/bootstrap-labels.sh"
+
+log "=== bootstrap complete (capabilities: $CAPABILITY_FILE) ==="

--- a/scripts/claude/detect-capabilities.sh
+++ b/scripts/claude/detect-capabilities.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# scripts/claude/detect-capabilities.sh
+#
+# Detect the availability of tools / integrations used by the DocDD flow and
+# print a schema-v1 JSON document to stdout. Logs and warnings go to stderr.
+#
+# Contract:
+#   stdout = valid JSON, 1 object, parseable by `jq`
+#   exit 0 on success (even when some capabilities are unknown/unavailable)
+#
+# Three-valued state per capability:
+#   "available"   : detected and usable
+#   "unavailable" : explicitly not installed / not configured
+#   "unknown"     : detection failed or was ambiguous (e.g. missing scope)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+warn() { printf 'warn: %s\n' "$*" >&2; }
+
+detected_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# ─── Repo owner / name (primary: gh, fallback: git remote parse) ────
+
+repo_owner="unknown"
+repo_name="unknown"
+if command -v gh >/dev/null 2>&1 && gh repo view --json owner,name >/dev/null 2>&1; then
+  repo_owner=$(gh repo view --json owner -q .owner.login 2>/dev/null || echo "unknown")
+  repo_name=$(gh repo view --json name -q .name 2>/dev/null || echo "unknown")
+else
+  if command -v git >/dev/null 2>&1; then
+    url=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo "")
+    case "$url" in
+      https://github.com/*)
+        rest="${url#https://github.com/}"
+        repo_owner="${rest%%/*}"
+        tail="${rest#*/}"
+        repo_name="${tail%.git}"
+        ;;
+      git@github.com:*)
+        rest="${url#git@github.com:}"
+        repo_owner="${rest%%/*}"
+        tail="${rest#*/}"
+        repo_name="${tail%.git}"
+        ;;
+    esac
+  fi
+fi
+
+# ─── gh_installed / gh_authenticated ─────────────────────
+
+gh_installed_state="unavailable"
+if command -v gh >/dev/null 2>&1; then
+  gh_installed_state="available"
+fi
+
+gh_auth_state="unknown"
+if [ "$gh_installed_state" = "available" ]; then
+  if gh auth status >/dev/null 2>&1; then
+    gh_auth_state="available"
+  else
+    gh_auth_state="unavailable"
+  fi
+fi
+
+# ─── repo_write_access ───────────────────────────────────
+
+repo_write_state="unknown"
+if [ "$gh_auth_state" = "available" ] && [ "$repo_owner" != "unknown" ] && [ "$repo_name" != "unknown" ]; then
+  push=$(gh api "repos/$repo_owner/$repo_name" -q .permissions.push 2>/dev/null || echo "")
+  case "$push" in
+    true)  repo_write_state="available" ;;
+    false) repo_write_state="unavailable" ;;
+    *)     repo_write_state="unknown" ;;
+  esac
+fi
+
+# ─── projects_api_available / owner_projects_count ───────
+
+projects_api_state="unknown"
+owner_projects_state="unknown"
+owner_projects_value="null"
+if [ "$gh_auth_state" = "available" ] && [ "$repo_owner" != "unknown" ]; then
+  # gh project list は `read:project` scope が無いと失敗する
+  if projects_json=$(gh project list --owner "$repo_owner" --limit 200 --format json 2>/dev/null); then
+    projects_api_state="available"
+    if count=$(printf '%s' "$projects_json" | jq '.projects | length' 2>/dev/null); then
+      owner_projects_state="available"
+      owner_projects_value="$count"
+    fi
+  fi
+fi
+
+# ─── codex_cli ───────────────────────────────────────────
+
+codex_state="unavailable"
+if command -v codex >/dev/null 2>&1; then
+  if codex --version >/dev/null 2>&1; then
+    codex_state="available"
+  else
+    codex_state="unknown"
+  fi
+fi
+
+# ─── mcp_servers / pencil_mcp / computer_use ─────────────
+#
+# Detection sources (only existing files are scanned):
+#   .claude/settings.json
+#   .claude/settings.local.json
+#   ~/.claude.json
+
+mcp_sources_json="[]"
+mcp_state="unknown"
+pencil_state="unknown"
+computer_use_state="unknown"
+
+declare -a sources=()
+[ -f "$REPO_ROOT/.claude/settings.json" ]        && sources+=("$REPO_ROOT/.claude/settings.json")
+[ -f "$REPO_ROOT/.claude/settings.local.json" ]  && sources+=("$REPO_ROOT/.claude/settings.local.json")
+[ -f "$HOME/.claude.json" ]                      && sources+=("$HOME/.claude.json")
+
+if [ "${#sources[@]}" -gt 0 ]; then
+  mcp_sources_json=$(printf '%s\n' "${sources[@]}" | jq -R . | jq -s .)
+
+  mcp_names=""
+  for f in "${sources[@]}"; do
+    names=$(jq -r '
+      (.mcpServers // {} | keys[]?),
+      (.projects // {} | to_entries[]? | .value.mcpServers // {} | keys[]?)
+    ' "$f" 2>/dev/null || true)
+    if [ -n "$names" ]; then
+      mcp_names+="$names"$'\n'
+    fi
+  done
+
+  if [ -n "$mcp_names" ]; then
+    mcp_state="available"
+    if printf '%s' "$mcp_names" | grep -qi 'pencil'; then
+      pencil_state="available"
+    else
+      pencil_state="unavailable"
+    fi
+  else
+    mcp_state="unavailable"
+    pencil_state="unavailable"
+  fi
+
+  # computer-use: 設定ファイル内のキーワード検出（permissions/tools 等に登場）
+  if grep -ql 'computer' "${sources[@]}" 2>/dev/null; then
+    if grep -q 'computer[-_]use\|computer_20\|anthropic.*computer' "${sources[@]}" 2>/dev/null; then
+      computer_use_state="available"
+    fi
+  fi
+  if [ "$computer_use_state" = "unknown" ]; then
+    computer_use_state="unavailable"
+  fi
+fi
+
+# ─── Build JSON ──────────────────────────────────────────
+
+jq -n \
+  --arg detected_at "$detected_at" \
+  --arg repo_owner "$repo_owner" \
+  --arg repo_name "$repo_name" \
+  --arg gh_installed "$gh_installed_state" \
+  --arg gh_auth "$gh_auth_state" \
+  --arg repo_write "$repo_write_state" \
+  --arg projects_api "$projects_api_state" \
+  --arg owner_projects_state "$owner_projects_state" \
+  --argjson owner_projects_value "$owner_projects_value" \
+  --arg codex "$codex_state" \
+  --arg mcp "$mcp_state" \
+  --argjson mcp_sources "$mcp_sources_json" \
+  --arg pencil "$pencil_state" \
+  --arg computer_use "$computer_use_state" \
+  '{
+    schema_version: 1,
+    detected_at: $detected_at,
+    repo_owner: $repo_owner,
+    repo_name: $repo_name,
+    capabilities: {
+      gh_installed: {
+        state: $gh_installed,
+        detection_source: "command -v gh"
+      },
+      gh_authenticated: {
+        state: $gh_auth,
+        detection_source: "gh auth status"
+      },
+      repo_write_access: {
+        state: $repo_write,
+        detection_source: "gh api repos/:owner/:repo -q .permissions.push"
+      },
+      projects_api_available: {
+        state: $projects_api,
+        detection_source: "gh project list --owner :login --limit 200 --format json"
+      },
+      owner_projects_count: {
+        state: $owner_projects_state,
+        value: $owner_projects_value,
+        detection_source: "gh project list --owner :login --limit 200 --format json | jq .projects | length (observed ceiling: 200)"
+      },
+      codex_cli: {
+        state: $codex,
+        detection_source: "command -v codex && codex --version"
+      },
+      mcp_servers: {
+        state: $mcp,
+        sources: $mcp_sources,
+        detection_source: ".claude/settings.json + .claude/settings.local.json + ~/.claude.json (.mcpServers keys)"
+      },
+      pencil_mcp: {
+        state: $pencil,
+        detection_source: "mcp_servers names matched against /pencil/i"
+      },
+      computer_use: {
+        state: $computer_use,
+        detection_source: ".claude/settings.json + .claude/settings.local.json grep computer-use"
+      }
+    }
+  }'

--- a/scripts/github/bootstrap-labels.sh
+++ b/scripts/github/bootstrap-labels.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# scripts/github/bootstrap-labels.sh
+#
+# Create/update GitHub labels from .github/labels.json idempotently via
+# `gh label create --force`.
+#
+# This script is normally invoked by `scripts/bootstrap.sh` after preflight
+# has passed. It can also be run standalone, in which case only minimal
+# checks (`gh`, `jq`) are performed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+log() { printf '%s\n' "$*" >&2; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+command -v gh >/dev/null 2>&1 || die "gh CLI が見つかりません"
+command -v jq >/dev/null 2>&1 || die "jq が見つかりません"
+
+LABELS_JSON="$REPO_ROOT/.github/labels.json"
+[ -f "$LABELS_JSON" ] || die ".github/labels.json が見つかりません: $LABELS_JSON"
+
+count=0
+while IFS= read -r row; do
+  name=$(jq -r '.name' <<<"$row")
+  color=$(jq -r '.color' <<<"$row")
+  desc=$(jq -r '.description' <<<"$row")
+  gh label create "$name" --color "$color" --description "$desc" --force >&2
+  count=$((count + 1))
+done < <(jq -c '.managed_labels[]' "$LABELS_JSON")
+
+log "bootstrap-labels: $count labels reconciled"


### PR DESCRIPTION
## 概要

fork 直後の最短経路で詰まるポイントを解消する Phase 0 bootstrap。
`make bootstrap` 一発で preflight → capability 検出 → GitHub ラベル収束まで走る。

## 関連 Issue

Closes #24（親 Epic: #23）

## 変更点

**新規ファイル**
- `.github/labels.json` — canonical 英語 13 + 日本語互換 9 = **22 ラベル** + `legacy_alias_map`
- `scripts/bootstrap.sh` — preflight 統括 wrapper（`gh`/`jq`/`git`/`gh auth`/`origin` fork/labels.json 構文/alias map）
- `scripts/claude/detect-capabilities.sh` — schema v1 JSON、3 値 state（`available`/`unavailable`/`unknown`）、9 capabilities
- `scripts/github/bootstrap-labels.sh` — `gh label create --force` で冪等ループ
- `docs/guides/bootstrap.md` — fork 直後の手順・対応 OS・トラブルシュート・capability 読解
- `.claude/references/capability-matrix.md` — Phase 0-F × 22 Issue の capability / Fallback 対応表
- `.claude/references/README.md` — references index

**既存更新**
- `Makefile` — `bootstrap` target（wrapper への 1 行 delegation）
- `README.md` — Bootstrap ガイドへのリンク 1 行
- `.claude/CLAUDE.md` — 新ディレクトリ（`docs/guides/`, `scripts/bootstrap.sh`, `scripts/claude/`, `scripts/github/`, `.claude/references/`）を構成図に追記

## 検証結果

`/5` で以下すべて PASS:

- [x] `make bootstrap` 初回成功（stdout 空、stderr に JSON pretty-print、`/tmp/docdd-capabilities.json` 生成）
- [x] 2 連続実行で `git status --porcelain` 無変更（冪等性、repo 配下 untracked 増加なし）
- [x] `detect-capabilities.sh | jq -e '.schema_version==1'` 成功
- [x] 日本語 9 ラベル厳密チェック（`grep -Fxf` + `diff` + `wc -l == 9`）
- [x] unmanaged labels 不変（before/after `cmp` byte 一致で既存ラベル保護確認）
- [x] preflight negative 5 本（gh/jq/git 不在・未認証・origin 非 fork）すべて明確なメッセージで非 0 停止（`mktemp -d` stub + `GH_CONFIG_DIR` で隔離実行）
- [x] `bash -n` 全 3 スクリプト構文 OK
- [x] CLAUDE.md 更新チェック済み

## スコープ外（後続 Issue）

- consumer 側の capability 参照実装 → Phase 1 Issue 1-1 以降
- `/1.create-issue.md` / `/2.plan-github-issue.md` の canonical 化 → Phase 2-1
- `shellcheck` CI 統合 → Phase 1 Issue 1-2 の `make shell-lint`

## Test plan

- [ ] GitHub Actions CI パス
- [ ] レビュアーによる fork 環境での `make bootstrap` 動作確認（任意）

🤖 Generated with [Claude Code](https://claude.com/claude-code)