### PR TITLE
feat(harness): settings.json baseline + hooks 3種

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -53,6 +53,7 @@ docdd-starters/
 │   └── modules/           # 再利用可能なインフラモジュール
 ├── .claude/
 │   ├── commands/          # カスタムスラッシュコマンド
+│   ├── hooks/             # PreToolUse / PostToolUse ガードレール
 │   ├── skills/            # AI実行知識（ドメイン・パターン）
 │   ├── rules/             # モジュール化ルール（命名・規約）
 │   └── references/        # コマンド/スキルから参照する静的ドキュメント

--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# block-dangerous.sh — PreToolUse hook for Bash commands
+# Hard-blocks destructive operations, asks for confirmation on risky ones.
+#
+# Hook output format:
+#   block:  {"decision": "block", "reason": "..."}
+#   ask:    {"hookSpecificOutput": {"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"..."}}
+#   allow:  (empty or no output — hook exits 0)
+
+set -euo pipefail
+
+# Read tool input from stdin
+INPUT=$(cat)
+
+# Extract the command string from tool_input.command
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+# ─── Hard Block ───────────────────────────────────────────────
+# These are ALWAYS blocked, no exceptions.
+
+# sudo
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)sudo\b'; then
+  echo '{"decision":"block","reason":"sudo is not allowed. Run commands without elevated privileges."}'
+  exit 0
+fi
+
+# git push --force (but NOT --force-with-lease)
+if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force($|\s|[;&|])' && \
+   ! echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force-with-lease'; then
+  echo '{"decision":"block","reason":"git push --force is blocked. Use --force-with-lease instead."}'
+  exit 0
+fi
+
+# git push -f (short flag, but NOT -fl or --force-with-lease)
+if echo "$COMMAND" | grep -qE 'git\s+push\s+(.*\s)?-f($|\s|[;&|])' && \
+   ! echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force-with-lease'; then
+  echo '{"decision":"block","reason":"git push -f is blocked. Use --force-with-lease instead."}'
+  exit 0
+fi
+
+# rm -rf / or rm -rf /* or rm --recursive --force / (root filesystem)
+if echo "$COMMAND" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r|--recursive\s+--force|--force\s+--recursive)[a-zA-Z]*\s+/(\.?\*)?($|\s)'; then
+  echo '{"decision":"block","reason":"rm -rf / is blocked. This would destroy the entire filesystem."}'
+  exit 0
+fi
+
+# gh api (arbitrary API calls)
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)gh\s+api\b'; then
+  echo '{"decision":"block","reason":"gh api is blocked. Use specific gh subcommands (gh issue, gh pr, etc.) instead."}'
+  exit 0
+fi
+
+# ─── Ask Escalation ──────────────────────────────────────────
+# These require user confirmation before proceeding.
+
+ask_reason=""
+
+# git reset --hard
+if echo "$COMMAND" | grep -qE 'git\s+reset\s+--hard'; then
+  ask_reason="git reset --hard discards uncommitted changes. Please confirm."
+fi
+
+# git push --delete / --mirror / :refspec (branch/tag deletion)
+if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--(delete|mirror)'; then
+  ask_reason="This push operation may delete remote refs. Please confirm."
+fi
+if echo "$COMMAND" | grep -qE 'git\s+push\s+\S+\s+:'; then
+  ask_reason="Pushing a :refspec deletes a remote branch/tag. Please confirm."
+fi
+
+# SQL destructive operations via psql/mysql
+if echo "$COMMAND" | grep -qiE '(psql|mysql).*\b(DROP|TRUNCATE)\b'; then
+  ask_reason="SQL DROP/TRUNCATE detected. This permanently destroys data. Please confirm."
+fi
+
+# rm targeting home, root-adjacent, or parent paths
+if echo "$COMMAND" | grep -qE 'rm\s+.*(\s|/)(\.\.|~|/home|/etc|/var|/usr)\b'; then
+  ask_reason="rm targeting a sensitive path. Please confirm."
+fi
+
+# make deploy-* (any deployment)
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)make\s+deploy'; then
+  ask_reason="Deployment command detected. Please confirm."
+fi
+
+# gh pr merge
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)gh\s+pr\s+merge'; then
+  ask_reason="PR merge via CLI. Please confirm."
+fi
+
+if [[ -n "$ask_reason" ]]; then
+  cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"$ask_reason"}}
+EOF
+  exit 0
+fi
+
+# No match — allow
+exit 0

--- a/.claude/hooks/detect-quality-issues.sh
+++ b/.claude/hooks/detect-quality-issues.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# detect-quality-issues.sh — PostToolUse hook for Write/Edit/MultiEdit
+# Warns when diff content contains quality-degrading patterns.
+# Inspects tool_input only (new/changed content), not existing file content.
+#
+# Hook output format:
+#   warning: {"systemMessage": "..."}
+#   clean:   (empty — exit 0)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract the content that was written/edited
+# For Write: tool_input.content
+# For Edit: tool_input.new_string
+# For MultiEdit: tool_input.edits[].new_string
+DIFF_CONTENT=$(echo "$INPUT" | jq -r '
+  (.tool_input.content // empty),
+  (.tool_input.new_string // empty),
+  ((.tool_input.edits // [])[] | .new_string // empty)
+' 2>/dev/null || true)
+
+if [[ -z "$DIFF_CONTENT" ]]; then
+  exit 0
+fi
+
+# ─── Quality pattern detection ────────────────────────────────
+WARNINGS=""
+
+# test.skip / describe.skip / it.skip
+if echo "$DIFF_CONTENT" | grep -qE '\b(test|describe|it)\.skip\b'; then
+  WARNINGS="${WARNINGS}\n- test.skip detected: skipped tests reduce coverage"
+fi
+
+# .only (test.only / describe.only / it.only)
+if echo "$DIFF_CONTENT" | grep -qE '\b(test|describe|it)\.only\b'; then
+  WARNINGS="${WARNINGS}\n- .only detected: this limits test execution to a single case"
+fi
+
+# eslint-disable
+if echo "$DIFF_CONTENT" | grep -qE 'eslint-disable'; then
+  WARNINGS="${WARNINGS}\n- eslint-disable detected: lint rules are disabled"
+fi
+
+# @ts-ignore / @ts-nocheck
+if echo "$DIFF_CONTENT" | grep -qE '@ts-ignore|@ts-nocheck'; then
+  WARNINGS="${WARNINGS}\n- @ts-ignore/@ts-nocheck detected: TypeScript type checking is bypassed"
+fi
+
+# strict: false (in config files)
+if echo "$DIFF_CONTENT" | grep -qE '"strict"\s*:\s*false|strict:\s*false'; then
+  WARNINGS="${WARNINGS}\n- strict: false detected: strict mode is being disabled"
+fi
+
+# pytest.mark.skip without reason
+if echo "$DIFF_CONTENT" | grep -qE '@pytest\.mark\.skip($|\s*\()' && \
+   ! echo "$DIFF_CONTENT" | grep -qE '@pytest\.mark\.skip\(reason='; then
+  WARNINGS="${WARNINGS}\n- pytest.mark.skip without reason: add a reason for skipping"
+fi
+
+# noqa without specific code
+if echo "$DIFF_CONTENT" | grep -qE '#\s*noqa($|\s)' && \
+   ! echo "$DIFF_CONTENT" | grep -qE '#\s*noqa:\s*[A-Z]'; then
+  WARNINGS="${WARNINGS}\n- noqa without specific code: use noqa: E501 format instead of blanket noqa"
+fi
+
+# ─── Unicode detection (prompt injection defense) ─────────────
+# Only run if python3 is available
+if command -v python3 &>/dev/null; then
+  UNICODE_ISSUES=$(echo "$DIFF_CONTENT" | python3 -c "
+import sys
+
+# Zero-width and invisible characters
+INVISIBLE = set(range(0x200B, 0x200E)) | {0x2060, 0xFEFF}
+# Bidirectional control characters
+BIDI = set(range(0x202A, 0x202F)) | set(range(0x2066, 0x206A))
+SUSPICIOUS = INVISIBLE | BIDI
+
+found = []
+for i, line in enumerate(sys.stdin, 1):
+    for j, ch in enumerate(line):
+        cp = ord(ch)
+        if cp in SUSPICIOUS:
+            found.append(f'  line {i}, col {j}: U+{cp:04X}')
+if found:
+    print('\n'.join(found[:5]))  # limit to 5 hits
+" 2>/dev/null || true)
+
+  if [[ -n "$UNICODE_ISSUES" ]]; then
+    WARNINGS="${WARNINGS}\n- Suspicious Unicode characters detected (possible prompt injection):\n${UNICODE_ISSUES}"
+  fi
+fi
+
+# ─── Output ───────────────────────────────────────────────────
+if [[ -n "$WARNINGS" ]]; then
+  MSG=$(printf 'Quality warnings in this change:%b' "$WARNINGS")
+  echo "$MSG" | jq -Rsc '{systemMessage: .}'
+  exit 0
+fi
+
+# Clean — no output
+exit 0

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# protect-files.sh — PreToolUse hook for Write/Edit/MultiEdit
+# Blocks writes to sensitive files: .env*, .git/, *.pem, *.key, id_rsa*
+# Exception: .env.example, .env.sample are allowed.
+#
+# Hook output format:
+#   block: {"decision": "block", "reason": "..."}
+#   allow: (empty — exit 0)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract file path from tool_input (Write/Edit use file_path)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Normalize: get the basename for pattern matching
+BASENAME=$(basename "$FILE_PATH")
+# Sanitize for safe JSON embedding
+SAFE_BASENAME=$(echo "$BASENAME" | sed 's/["\\/]/\\&/g')
+
+# ─── .env files (block, except .env.example and .env.sample) ─
+if echo "$BASENAME" | grep -qE '^\.env'; then
+  if echo "$BASENAME" | grep -qE '^\.env\.(example|sample)$'; then
+    exit 0  # allowed
+  fi
+  echo "{\"decision\":\"block\",\"reason\":\"Writing to $SAFE_BASENAME is blocked. Secrets files (.env*) must be managed manually. Use .env.example for templates.\"}"
+  exit 0
+fi
+
+# ─── .git/ directory ─────────────────────────────────────────
+if echo "$FILE_PATH" | grep -qE '(^|/)\.git/'; then
+  echo "{\"decision\":\"block\",\"reason\":\"Writing to .git/ internals is blocked. Use git commands instead.\"}"
+  exit 0
+fi
+
+# ─── Private keys: *.pem, *.key ──────────────────────────────
+if echo "$BASENAME" | grep -qE '\.(pem|key)$'; then
+  echo "{\"decision\":\"block\",\"reason\":\"Writing to $SAFE_BASENAME is blocked. Private key files must be managed manually.\"}"
+  exit 0
+fi
+
+# ─── SSH keys: id_rsa* ───────────────────────────────────────
+if echo "$BASENAME" | grep -qE '^id_rsa'; then
+  echo "{\"decision\":\"block\",\"reason\":\"Writing to $SAFE_BASENAME is blocked. SSH key files must be managed manually.\"}"
+  exit 0
+fi
+
+# No match — allow
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,183 @@
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git tag:*)",
+      "Bash(git stash list:*)",
+      "Bash(git stash show:*)",
+      "Bash(git remote:*)",
+      "Bash(git fetch:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git rev-list:*)",
+      "Bash(git symbolic-ref:*)",
+      "Bash(git config --get:*)",
+      "Bash(git config --list:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git ls-remote:*)",
+      "Bash(git merge-base:*)",
+      "Bash(git name-rev:*)",
+      "Bash(git describe:*)",
+      "Bash(git shortlog:*)",
+      "Bash(git blame:*)",
+      "Bash(git cherry:*)",
+      "Bash(git reflog:*)",
+      "Bash(git worktree list:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git merge:*)",
+      "Bash(git rebase:*)",
+      "Bash(git cherry-pick:*)",
+      "Bash(git stash:*)",
+      "Bash(git worktree add:*)",
+      "Bash(git worktree remove:*)",
+      "Bash(git push -u:*)",
+      "Bash(git push origin:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue create:*)",
+      "Bash(gh issue edit:*)",
+      "Bash(gh issue close:*)",
+      "Bash(gh issue reopen:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr status:*)",
+      "Bash(gh pr checkout:*)",
+      "Bash(gh pr ready:*)",
+      "Bash(gh pr review:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh project view:*)",
+      "Bash(gh project list:*)",
+      "Bash(gh project item-list:*)",
+      "Bash(gh project item-edit:*)",
+      "Bash(gh project item-add:*)",
+      "Bash(gh label list:*)",
+      "Bash(gh label create:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run watch:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh auth status:*)",
+      "Bash(make test:*)",
+      "Bash(make test-backend:*)",
+      "Bash(make test-frontend:*)",
+      "Bash(make lint:*)",
+      "Bash(make traceability:*)",
+      "Bash(pytest:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(npm test:*)",
+      "Bash(npm run test:*)",
+      "Bash(npm run lint:*)",
+      "Bash(npm run check:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npx biome:*)",
+      "Bash(npx vitest:*)",
+      "Bash(npx next lint:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(wc:*)",
+      "Bash(find:*)",
+      "Bash(which:*)",
+      "Bash(echo:*)",
+      "Bash(pwd:*)",
+      "Bash(env:*)",
+      "Bash(date:*)",
+      "Bash(mkdir:*)",
+      "Bash(touch:*)",
+      "Bash(cp:*)",
+      "Bash(chmod:*)",
+      "Bash(sort:*)",
+      "Bash(uniq:*)",
+      "Bash(diff:*)",
+      "Bash(jq:*)",
+      "Bash(curl:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(node:*)",
+      "Bash(npm install:*)",
+      "Bash(npm ci:*)",
+      "Bash(npm run build:*)",
+      "Bash(npm run dev:*)",
+      "Bash(pip install:*)",
+      "Bash(pip freeze:*)",
+      "Bash(pip list:*)",
+      "Bash(docker ps:*)",
+      "Bash(docker logs:*)",
+      "Bash(docker compose up:*)",
+      "Bash(docker compose down:*)",
+      "Bash(docker compose build:*)"
+    ],
+    "ask": [
+      "Bash(git push --force-with-lease:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git push --delete:*)",
+      "Bash(git push --mirror:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh pr close:*)",
+      "Bash(gh issue delete:*)",
+      "Bash(make deploy:*)",
+      "Bash(make deploy-stg:*)",
+      "Bash(make deploy-prod:*)",
+      "Bash(make deploy-backend-prod:*)",
+      "Bash(make tf-apply:*)",
+      "Bash(make tf-destroy:*)",
+      "Bash(make ecs-sh:*)",
+      "Bash(rm:*)",
+      "Bash(mv:*)",
+      "Bash(docker compose rm:*)",
+      "Bash(docker system prune:*)",
+      "Bash(pip uninstall:*)",
+      "Bash(npm uninstall:*)"
+    ],
+    "deny": [
+      "Bash(gh api:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-files.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/detect-quality-issues.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/docs/guides/harness-customization.md
+++ b/docs/guides/harness-customization.md
@@ -1,0 +1,203 @@
+# Claude Code ハーネス カスタマイズガイド
+
+fork 先プロジェクトが `.claude/settings.json` と hooks を自分の環境に合わせて拡張するための手順書です。
+
+## 概要
+
+docdd-starters は **最小限の安全網（baseline）** を提供します。
+
+| レイヤー | 役割 | ファイル |
+|---------|------|---------|
+| **settings.json** | allow / ask / deny のパーミッション | `.claude/settings.json` |
+| **hooks** | PreToolUse / PostToolUse のガードレール | `.claude/hooks/*.sh` |
+| **settings.local.json** | 個人/プロジェクト固有の上書き | `.claude/settings.local.json` |
+
+## settings.json vs settings.local.json
+
+| | settings.json | settings.local.json |
+|---|---|---|
+| **管理** | Git にコミット（チーム共有） | `.gitignore` 対象（個人設定） |
+| **用途** | baseline ポリシー | 個人の追加 allow / deny 上書き |
+| **優先度** | ベース | settings.json を上書き |
+
+### 上書きの例
+
+baseline で `gh api` が deny されているが、CI スクリプトで必要な場合:
+
+```json
+// .claude/settings.local.json
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh api repos/myorg/myrepo:*)"
+    ]
+  }
+}
+```
+
+## Baseline 構成
+
+### allow（約 100 項目）
+
+読み取り系 git / gh サブコマンド / テスト・リント / 一般的な CLI ツール。
+
+### ask（約 20 項目）
+
+確認が必要な操作:
+
+- `git push --force-with-lease` / `git reset --hard` / `git push --delete`
+- `gh pr merge` / `gh pr close`
+- `make deploy-*` / `make tf-apply` / `make tf-destroy`
+- `rm` / `mv`
+
+### deny（1 項目）
+
+- `gh api` — 任意のエンドポイントを叩けるバイパス経路。個別サブコマンド（`gh issue`, `gh pr` 等）は allow 済み。
+
+## hooks 構成
+
+### 1. block-dangerous.sh（PreToolUse + Bash）
+
+| 種別 | パターン | 動作 |
+|------|---------|------|
+| **Hard block** | `sudo` | block |
+| **Hard block** | `git push --force` / `-f`（`--force-with-lease` 除外） | block |
+| **Hard block** | `rm -rf /` | block |
+| **Hard block** | `gh api` | block |
+| **Ask** | `git reset --hard` | ask 昇格 |
+| **Ask** | `git push --delete` / `--mirror` / `:refspec` | ask 昇格 |
+| **Ask** | `psql`/`mysql` + `DROP`/`TRUNCATE` | ask 昇格 |
+| **Ask** | `rm` + 危険パス | ask 昇格 |
+| **Ask** | `make deploy-*` | ask 昇格 |
+| **Ask** | `gh pr merge` | ask 昇格 |
+
+### 2. protect-files.sh（PreToolUse + Write/Edit/MultiEdit）
+
+| パターン | 動作 | 例外 |
+|---------|------|------|
+| `.env*` | block | `.env.example`, `.env.sample` |
+| `.git/` | block | — |
+| `*.pem`, `*.key` | block | — |
+| `id_rsa*` | block | — |
+
+### 3. detect-quality-issues.sh（PostToolUse + Write/Edit/MultiEdit）
+
+diff 内容のみを検査し、以下のパターンに警告を出す:
+
+| パターン | 意味 |
+|---------|------|
+| `test.skip` / `describe.skip` / `it.skip` | テストスキップ |
+| `.only` | テスト限定実行 |
+| `eslint-disable` | リントルール無効化 |
+| `@ts-ignore` / `@ts-nocheck` | TypeScript 型チェック回避 |
+| `strict: false` | strict モード無効化 |
+| `pytest.mark.skip`（reason なし） | reason なしの pytest スキップ |
+| `noqa`（コードなし） | blanket noqa |
+| 不可視 Unicode 文字 | プロンプトインジェクション対策 |
+
+## カスタマイズ方法
+
+### パターン 1: プロジェクト固有のコマンドを allow に追加
+
+```json
+// settings.json の permissions.allow に追加
+"Bash(alembic:*)",
+"Bash(make migrate:*)",
+"Bash(terraform plan:*)"
+```
+
+### パターン 2: Docker 操作を追加
+
+```json
+// settings.json の permissions.allow に追加
+"Bash(docker exec:*)",
+"Bash(docker compose exec:*)",
+"Bash(docker compose logs:*)"
+```
+
+### パターン 3: 特定のデプロイを allow に昇格
+
+ask から allow に移動する場合、ask から削除して allow に追加:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(make deploy-stg:*)"
+    ]
+  }
+}
+```
+
+### パターン 4: hooks にプロジェクト固有ルールを追加
+
+`block-dangerous.sh` に追加パターンを入れる場合:
+
+```bash
+# ─── Project-specific blocks ──────────────────────────────────
+# Example: block direct database access in production
+if echo "$COMMAND" | grep -qE 'psql.*production'; then
+  echo '{"decision":"block","reason":"Direct production database access is blocked."}'
+  exit 0
+fi
+```
+
+### パターン 5: detect-quality-issues.sh に検出パターンを追加
+
+```bash
+# Example: warn on console.log in production code
+if echo "$DIFF_CONTENT" | grep -qE 'console\.log\('; then
+  WARNINGS="${WARNINGS}\n- console.log detected: remove before merging"
+fi
+```
+
+## hooks 出力フォーマット
+
+hooks が Claude Code と通信するための JSON フォーマット:
+
+### PreToolUse hooks
+
+```bash
+# Block（完全拒否）
+echo '{"decision":"block","reason":"Explanation of why this is blocked."}'
+
+# Ask（ユーザー確認を要求）
+echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"Explanation."}}'
+
+# Allow（何も出力しない）
+exit 0
+```
+
+### PostToolUse hooks
+
+```bash
+# Warning（システムメッセージとして表示）
+echo '{"systemMessage":"Warning: description of the issue."}'
+
+# Clean（何も出力しない）
+exit 0
+```
+
+## トラブルシューティング
+
+### hooks が動作しない
+
+1. 実行権限を確認: `ls -la .claude/hooks/*.sh`
+2. `chmod +x .claude/hooks/*.sh` で権限を付与
+3. `jq` がインストールされているか確認: `which jq`
+
+### settings.local.json が反映されない
+
+- JSON の構文エラーがないか確認: `jq . .claude/settings.local.json`
+- `permissions` キーの構造が正しいか確認
+
+### Unicode 検出が動作しない
+
+- `python3` が PATH 上にあるか確認: `which python3`
+- python3 が存在しない場合、Unicode 検出はスキップされます（他の検出は動作します）
+
+## 関連ファイル
+
+- [.claude/settings.json](../../.claude/settings.json) — baseline ポリシー
+- [.claude/hooks/](../../.claude/hooks/) — hook スクリプト
+- [.claude/rules/](../../.claude/rules/) — コーディング規約


### PR DESCRIPTION
## 概要

fork 先が即採用できる最小限の安全網（baseline）を構築。
settings.json の allow/ask/deny ポリシー + PreToolUse/PostToolUse hooks 3 種 + fork 先向けカスタマイズガイド。

## 関連 Issue

Closes #25
Parent Epic: #23

## 変更点

### settings.json baseline
- **allow** (~120 項目): 読み取り系 git/gh、テスト・リント、一般 CLI ツール
- **ask** (~20 項目): force-with-lease、deploy、rm/mv、PR merge 等
- **deny** (1 項目): `gh api`（任意エンドポイントへのバイパス経路を遮断）
- 既存 `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` を維持

### hooks 3 種（`.claude/hooks/`）
| hook | タイミング | 概要 |
|------|-----------|------|
| `block-dangerous.sh` | PreToolUse + Bash | sudo / force-push / rm -rf / gh api の hard block + 危険操作の ask 昇格 |
| `protect-files.sh` | PreToolUse + Write\|Edit | .env* / .git/ / *.pem / *.key / id_rsa* の書き込み保護 |
| `detect-quality-issues.sh` | PostToolUse + Write\|Edit | test.skip / eslint-disable / @ts-ignore 等の品質警告 + 不可視 Unicode 検出 |

### ドキュメント
- `docs/guides/harness-customization.md`: fork 先が settings.json と hooks を拡張する手順

### CLAUDE.md
- プロジェクト構成に `.claude/hooks/` を追記

## 検証結果

- [x] `/5` で検証済み（[コメント](https://github.com/syotakokichi/docdd-starters/issues/25#issuecomment-4230841108)）
- [x] 手動テスト #1-#9 全パス
- [x] 独立レビュー（エージェント）で指摘 3 件を修正:
  - `git push -f` の正規表現修正
  - `rm -rf /*` / `rm --recursive --force /` のパターン追加
  - `protect-files.sh` のファイル名 JSON サニタイズ
- [x] CLAUDE.md 更新チェック済み

## サイズチェック

| 指標 | 値 | 判定 |
|------|:--:|:----:|
| 変更対象ファイル | 6 | OK |
| 追加行数 | 642 | OK |


🤖 Generated with [Claude Code](https://claude.com/claude-code)
