### PR TITLE
feat(harness): cli-first ルール + shell QA 基盤

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -109,6 +109,7 @@ docdd-starters/
 | [issue-sizing](./rules/issue-sizing.md) | Issue サイジングルール |
 | [brand](./rules/brand.md) | ブランドガイドライン（テンプレート） |
 | [codex-review](./rules/codex-review.md) | Codex CLI レビュー運用ルール |
+| [cli-first](./rules/cli-first.md) | CLI ファースト原則（MCP より CLI 優先） |
 
 **詳細**: [rules/README.md](./rules/README.md)
 

--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -29,15 +29,15 @@ if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)sudo\b'; then
 fi
 
 # git push --force (but NOT --force-with-lease)
-if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force($|\s|[;&|])' && \
-   ! echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force-with-lease'; then
+if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force($|\s|[;&|])' \
+  && ! echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force-with-lease'; then
   echo '{"decision":"block","reason":"git push --force is blocked. Use --force-with-lease instead."}'
   exit 0
 fi
 
 # git push -f (short flag, but NOT -fl or --force-with-lease)
-if echo "$COMMAND" | grep -qE 'git\s+push\s+(.*\s)?-f($|\s|[;&|])' && \
-   ! echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force-with-lease'; then
+if echo "$COMMAND" | grep -qE 'git\s+push\s+(.*\s)?-f($|\s|[;&|])' \
+  && ! echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force-with-lease'; then
   echo '{"decision":"block","reason":"git push -f is blocked. Use --force-with-lease instead."}'
   exit 0
 fi

--- a/.claude/hooks/detect-quality-issues.sh
+++ b/.claude/hooks/detect-quality-issues.sh
@@ -54,14 +54,14 @@ if echo "$DIFF_CONTENT" | grep -qE '"strict"\s*:\s*false|strict:\s*false'; then
 fi
 
 # pytest.mark.skip without reason
-if echo "$DIFF_CONTENT" | grep -qE '@pytest\.mark\.skip($|\s*\()' && \
-   ! echo "$DIFF_CONTENT" | grep -qE '@pytest\.mark\.skip\(reason='; then
+if echo "$DIFF_CONTENT" | grep -qE '@pytest\.mark\.skip($|\s*\()' \
+  && ! echo "$DIFF_CONTENT" | grep -qE '@pytest\.mark\.skip\(reason='; then
   WARNINGS="${WARNINGS}\n- pytest.mark.skip without reason: add a reason for skipping"
 fi
 
 # noqa without specific code
-if echo "$DIFF_CONTENT" | grep -qE '#\s*noqa($|\s)' && \
-   ! echo "$DIFF_CONTENT" | grep -qE '#\s*noqa:\s*[A-Z]'; then
+if echo "$DIFF_CONTENT" | grep -qE '#\s*noqa($|\s)' \
+  && ! echo "$DIFF_CONTENT" | grep -qE '#\s*noqa:\s*[A-Z]'; then
   WARNINGS="${WARNINGS}\n- noqa without specific code: use noqa: E501 format instead of blanket noqa"
 fi
 

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -26,7 +26,7 @@ SAFE_BASENAME=$(echo "$BASENAME" | sed 's/["\\/]/\\&/g')
 # ─── .env files (block, except .env.example and .env.sample) ─
 if echo "$BASENAME" | grep -qE '^\.env'; then
   if echo "$BASENAME" | grep -qE '^\.env\.(example|sample)$'; then
-    exit 0  # allowed
+    exit 0 # allowed
   fi
   echo "{\"decision\":\"block\",\"reason\":\"Writing to $SAFE_BASENAME is blocked. Secrets files (.env*) must be managed manually. Use .env.example for templates.\"}"
   exit 0

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -19,6 +19,7 @@ Claude Code が従うべきコーディング規約と命名規則を定義し�
 | [issue-sizing.md](./issue-sizing.md) | Issue サイジングルール |
 | [brand.md](./brand.md) | ブランドガイドライン（テンプレート） |
 | [codex-review.md](./codex-review.md) | Codex CLI レビュー運用ルール |
+| [cli-first.md](./cli-first.md) | CLI ファースト原則（MCP より CLI 優先） |
 
 ## 基本原則
 

--- a/.claude/rules/cli-first.md
+++ b/.claude/rules/cli-first.md
@@ -1,0 +1,73 @@
+# CLI-First 原則
+
+## 概要
+
+MCP サーバーより CLI ツール（`gh`, `git`, `make`, `jq` 等）を優先する設計原則。
+CLI は透過的でログが残り、hook で制御でき、CI でも再現可能。
+
+---
+
+## 判断フロー
+
+```
+操作を実行したい
+  │
+  ├─ gh / git / make / jq で完結する？
+  │    └─ YES → CLI を使う（MCP 不要）
+  │
+  ├─ CLI では不可能 or 著しく非効率？
+  │    └─ YES → MCP 例外リストに該当する？
+  │         ├─ YES → MCP を使う
+  │         └─ NO  → CLI の組み合わせで代替できないか再検討
+  │
+  └─ どちらでも可能？
+       └─ CLI を優先（hook / CI 再現性のため）
+```
+
+---
+
+## CLI で十分な操作
+
+以下の操作は CLI で完結する。MCP を使わない。
+
+| 操作 | CLI コマンド |
+|------|-------------|
+| Issue 作成・編集・検索 | `gh issue create / edit / list / view` |
+| PR 作成・レビュー | `gh pr create / review / merge` |
+| ラベル管理 | `gh label create --force` |
+| Projects 操作 | `gh project item-add / item-edit` |
+| ブランチ操作 | `git branch / checkout / switch` |
+| diff / log 確認 | `git diff / log / show` |
+| ビルド・テスト | `make test / make shell-lint` |
+| JSON 加工 | `jq` |
+| ファイル検索 | `find / grep / rg` |
+
+---
+
+## MCP 例外ケース
+
+以下は CLI では実現できない、または著しく非効率なため MCP の使用を許可する。
+
+| MCP サーバー | 用途 | CLI 代替が不十分な理由 |
+|-------------|------|----------------------|
+| `chrome-devtools` | ブラウザ操作・スクリーンショット | CLI ではブラウザ制御不可 |
+| `postgres` | DB クエリ・スキーマ確認 | `psql` は対話的で自動化が煩雑 |
+| `aws-docs` | AWS ドキュメント検索 | CLI (`aws`) はドキュメント検索非対応 |
+| `terraform` | Terraform state 参照 | `terraform` CLI で可能だが MCP の方が安全 |
+| `pencil` | Pencil.dev デザイン操作 | CLI API が存在しない |
+
+---
+
+## ルール
+
+1. **CLI 優先**: `gh` / `git` / `make` で完結する操作は MCP を使わない
+2. **例外明示**: MCP を使う場合は、なぜ CLI では不十分かを説明できること
+3. **Hook 互換**: CLI 経由の操作は `.claude/hooks/` でガードレールが効く。MCP 経由だと hook をバイパスするリスクがある
+4. **CI 再現性**: CLI コマンドは CI workflow にそのまま転用できる。MCP は CI では利用不可
+
+---
+
+## 関連ファイル
+
+- [.claude/hooks/](../hooks/) - CLI 操作に対する PreToolUse / PostToolUse hook
+- [completion-quality.md](./completion-quality.md) - 完了品質ルール

--- a/.github/workflows/docdd-starters-ci.yml
+++ b/.github/workflows/docdd-starters-ci.yml
@@ -42,6 +42,25 @@ jobs:
       - name: Run backend tests
         run: PYTHONPATH=apps/backend pytest tests/backend
 
+  shell-qa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shfmt
+        run: |
+          curl -sS https://webi.sh/shfmt | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Install bats
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq bats
+      - name: shellcheck
+        run: make shell-lint
+      - name: shfmt
+        run: make shell-format-check
+      - name: bats
+        run: make test-hooks
+
   frontend-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         files: ^(\.claude/hooks/|scripts/).*\.sh$
         args: ["--severity=warning"]
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.8.0.1
+    rev: v3.8.0-1
     hooks:
       - id: shfmt
         files: ^(\.claude/hooks/|scripts/).*\.sh$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,18 @@ repos:
       - id: end-of-file-fixer
       - id: check-json
       - id: check-yaml
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        files: ^(\.claude/hooks/|scripts/).*\.sh$
+        args: ["--severity=warning"]
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.8.0.1
+    hooks:
+      - id: shfmt
+        files: ^(\.claude/hooks/|scripts/).*\.sh$
+        args: ["-i", "2", "-ci", "-bn"]
   - repo: local
     hooks:
       - id: biome-frontend-starter

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: tf-init tf-plan tf-apply tf-destroy tf-output
 .PHONY: deploy-backend-stg deploy-frontend-stg deploy-stg deploy-backend-prod deploy-frontend-prod deploy-prod
 .PHONY: ecs-status ecs-logs-backend ecs-logs-frontend ecs-sh
+.PHONY: shell-lint shell-format-check test-hooks
 
 # ─── Bootstrap ───────────────────────────────────────────
 
@@ -44,6 +45,38 @@ install:
 install-dev:
 	npm --prefix apps/frontend install
 	pip install -r apps/backend/requirements-dev.txt
+
+# ─── Shell QA ────────────────────────────────────────────
+
+SHELL_FILES := .claude/hooks/block-dangerous.sh \
+	.claude/hooks/protect-files.sh \
+	.claude/hooks/detect-quality-issues.sh \
+	scripts/bootstrap.sh \
+	scripts/claude/detect-capabilities.sh \
+	scripts/deploy/terraform.sh \
+	scripts/deploy/build-and-deploy.sh \
+	scripts/github/bootstrap-labels.sh
+
+shell-lint:
+	@if command -v shellcheck >/dev/null 2>&1; then \
+		shellcheck --severity=warning $(SHELL_FILES); \
+	else \
+		echo "WARN: shellcheck not found, skipping shell-lint"; \
+	fi
+
+shell-format-check:
+	@if command -v shfmt >/dev/null 2>&1; then \
+		shfmt -i 2 -ci -bn -d $(SHELL_FILES); \
+	else \
+		echo "WARN: shfmt not found, skipping shell-format-check"; \
+	fi
+
+test-hooks:
+	@if command -v bats >/dev/null 2>&1; then \
+		bats scripts/claude/test-hooks.bats; \
+	else \
+		echo "WARN: bats not found, skipping test-hooks"; \
+	fi
 
 # ─── Terraform ───────────────────────────────────────────
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -16,12 +16,15 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 log() { printf '%s\n' "$*" >&2; }
-die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
 
 # ─── Preflight ───────────────────────────────────────────
 
-command -v gh  >/dev/null 2>&1 || die "gh CLI が見つかりません。https://cli.github.com/ からインストールしてください"
-command -v jq  >/dev/null 2>&1 || die "jq が見つかりません。\`brew install jq\` または \`apt install jq\` を実行してください"
+command -v gh >/dev/null 2>&1 || die "gh CLI が見つかりません。https://cli.github.com/ からインストールしてください"
+command -v jq >/dev/null 2>&1 || die "jq が見つかりません。\`brew install jq\` または \`apt install jq\` を実行してください"
 command -v git >/dev/null 2>&1 || die "git が見つかりません。git をインストールしてください"
 
 if ! gh auth status >/dev/null 2>&1; then
@@ -92,7 +95,7 @@ log "preflight OK (owner=$gh_login, labels=$(jq '.managed_labels | length' "$LAB
 
 CAPABILITY_FILE="${DOCDD_CAPABILITY_FILE:-/tmp/docdd-capabilities.json}"
 
-"$REPO_ROOT/scripts/claude/detect-capabilities.sh" > "$CAPABILITY_FILE"
+"$REPO_ROOT/scripts/claude/detect-capabilities.sh" >"$CAPABILITY_FILE"
 
 log "=== capabilities ==="
 jq . "$CAPABILITY_FILE" >&2

--- a/scripts/claude/detect-capabilities.sh
+++ b/scripts/claude/detect-capabilities.sh
@@ -71,9 +71,9 @@ repo_write_state="unknown"
 if [ "$gh_auth_state" = "available" ] && [ "$repo_owner" != "unknown" ] && [ "$repo_name" != "unknown" ]; then
   push=$(gh api "repos/$repo_owner/$repo_name" -q .permissions.push 2>/dev/null || echo "")
   case "$push" in
-    true)  repo_write_state="available" ;;
+    true) repo_write_state="available" ;;
     false) repo_write_state="unavailable" ;;
-    *)     repo_write_state="unknown" ;;
+    *) repo_write_state="unknown" ;;
   esac
 fi
 
@@ -117,9 +117,9 @@ pencil_state="unknown"
 computer_use_state="unknown"
 
 declare -a sources=()
-[ -f "$REPO_ROOT/.claude/settings.json" ]        && sources+=("$REPO_ROOT/.claude/settings.json")
-[ -f "$REPO_ROOT/.claude/settings.local.json" ]  && sources+=("$REPO_ROOT/.claude/settings.local.json")
-[ -f "$HOME/.claude.json" ]                      && sources+=("$HOME/.claude.json")
+[ -f "$REPO_ROOT/.claude/settings.json" ] && sources+=("$REPO_ROOT/.claude/settings.json")
+[ -f "$REPO_ROOT/.claude/settings.local.json" ] && sources+=("$REPO_ROOT/.claude/settings.local.json")
+[ -f "$HOME/.claude.json" ] && sources+=("$HOME/.claude.json")
 
 if [ "${#sources[@]}" -gt 0 ]; then
   mcp_sources_json=$(printf '%s\n' "${sources[@]}" | jq -R . | jq -s .)

--- a/scripts/claude/test-hooks.bats
+++ b/scripts/claude/test-hooks.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# scripts/claude/test-hooks.bats
+#
+# Fixture tests for .claude/hooks/ scripts.
+# Each test pipes a JSON payload (matching Claude Code hook input format)
+# into the hook script and asserts the output.
+
+HOOKS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.claude/hooks" && pwd)"
+
+# ─── block-dangerous.sh ──────────────────────────────────
+
+@test "block-dangerous: sudo rm -rf / is blocked" {
+  input='{"tool_name":"Bash","tool_input":{"command":"sudo rm -rf /"}}'
+  result=$(echo "$input" | "$HOOKS_DIR/block-dangerous.sh")
+  echo "$result" | grep -q '"decision":"block"'
+}
+
+@test "block-dangerous: git reset --hard HEAD~1 triggers ask" {
+  input='{"tool_name":"Bash","tool_input":{"command":"git reset --hard HEAD~1"}}'
+  result=$(echo "$input" | "$HOOKS_DIR/block-dangerous.sh")
+  echo "$result" | grep -q '"permissionDecision":"ask"'
+}
+
+@test "block-dangerous: gh api is blocked" {
+  input='{"tool_name":"Bash","tool_input":{"command":"gh api repos/owner/repo"}}'
+  result=$(echo "$input" | "$HOOKS_DIR/block-dangerous.sh")
+  echo "$result" | grep -q '"decision":"block"'
+}
+
+@test "block-dangerous: safe git command is allowed" {
+  input='{"tool_name":"Bash","tool_input":{"command":"git status"}}'
+  result=$(echo "$input" | "$HOOKS_DIR/block-dangerous.sh")
+  [ -z "$result" ]
+}
+
+# ─── protect-files.sh ────────────────────────────────────
+
+@test "protect-files: .env write is blocked" {
+  input='{"tool_name":"Write","tool_input":{"file_path":".env","content":"SECRET=xxx"}}'
+  result=$(echo "$input" | "$HOOKS_DIR/protect-files.sh")
+  echo "$result" | grep -q '"decision":"block"'
+}
+
+@test "protect-files: .env.example write is allowed" {
+  input='{"tool_name":"Write","tool_input":{"file_path":".env.example","content":"KEY=value"}}'
+  result=$(echo "$input" | "$HOOKS_DIR/protect-files.sh")
+  [ -z "$result" ]
+}
+
+@test "protect-files: .git/config write is blocked" {
+  input='{"tool_name":"Write","tool_input":{"file_path":".git/config","content":"[core]"}}'
+  result=$(echo "$input" | "$HOOKS_DIR/protect-files.sh")
+  echo "$result" | grep -q '"decision":"block"'
+}
+
+# ─── detect-quality-issues.sh ────────────────────────────
+
+@test "detect-quality-issues: test.skip triggers warning" {
+  input='{"tool_name":"Edit","tool_input":{"new_string":"test.skip(\"reason\")"}}'
+  result=$(echo "$input" | "$HOOKS_DIR/detect-quality-issues.sh")
+  echo "$result" | grep -q 'systemMessage'
+  echo "$result" | grep -q 'test.skip'
+}
+
+@test "detect-quality-issues: clean code produces no output" {
+  input='{"tool_name":"Write","tool_input":{"content":"const x = 1;"}}'
+  result=$(echo "$input" | "$HOOKS_DIR/detect-quality-issues.sh")
+  [ -z "$result" ]
+}

--- a/scripts/deploy/build-and-deploy.sh
+++ b/scripts/deploy/build-and-deploy.sh
@@ -22,8 +22,8 @@ echo "ECS: ${ECS_CLUSTER} / ${SERVICE}"
 
 # 1. ECR login
 echo "--- ECR Login ---"
-aws ecr get-login-password --region "$AWS_REGION" | \
-  docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 
 # 2. Build (AMD64 for Fargate)
 echo "--- Build ---"

--- a/scripts/github/bootstrap-labels.sh
+++ b/scripts/github/bootstrap-labels.sh
@@ -14,7 +14,10 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 log() { printf '%s\n' "$*" >&2; }
-die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
 
 command -v gh >/dev/null 2>&1 || die "gh CLI が見つかりません"
 command -v jq >/dev/null 2>&1 || die "jq が見つかりません"


### PR DESCRIPTION
## 概要

CLI ファースト原則をルールとして明文化し、shell スクリプトの品質ゲート（shellcheck / shfmt / bats）を Phase 1 で確立する。

## 関連Issue

Closes #26

## 変更点

### 新規ファイル
- `.claude/rules/cli-first.md` — MCP より CLI 優先の判断基準（判断フロー図、CLI 操作一覧、MCP 例外ケース）
- `scripts/claude/test-hooks.bats` — hooks の bats テスト（9 ケース）

### 既存ファイル変更
- `.pre-commit-config.yaml` — shellcheck (v0.10.0) + shfmt (v3.8.0.1) hook 追加
- `Makefile` — `shell-lint` / `shell-format-check` / `test-hooks` ターゲット追加
- `.github/workflows/docdd-starters-ci.yml` — `shell-qa` ジョブ追加（shellcheck + shfmt + bats）
- `.claude/CLAUDE.md` / `.claude/rules/README.md` — cli-first ルールのリンク追加
- 既存スクリプト 7 本 — `shfmt -i 2 -ci -bn` による整形（ロジック変更なし）

## 検証結果

- [x] `/5` で検証済み（[コメント](https://github.com/syotakokichi/docdd-starters/issues/26#issuecomment-4231554149)）
- [x] `make shell-lint` PASS
- [x] `make shell-format-check` PASS（差分なし）
- [x] `make test-hooks` 9/9 PASS
- [x] CLAUDE.md 更新チェック済み