### PR TITLE
feat(ci): Claude config baseline validator + traceability CI gate

### DIFF
--- a/.github/workflows/docdd-starters-ci.yml
+++ b/.github/workflows/docdd-starters-ci.yml
@@ -61,6 +61,20 @@ jobs:
       - name: bats
         run: make test-hooks
 
+  docdd-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install jq
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
+      - name: Validate Claude config
+        run: make validate-claude
+      - name: Validate traceability
+        run: make traceability
+
   frontend-tests:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 .PHONY: deploy-backend-stg deploy-frontend-stg deploy-stg deploy-backend-prod deploy-frontend-prod deploy-prod
 .PHONY: ecs-status ecs-logs-backend ecs-logs-frontend ecs-sh
 .PHONY: shell-lint shell-format-check test-hooks
+.PHONY: validate-claude
+
+PYTHON ?= python3
 
 # ─── Bootstrap ───────────────────────────────────────────
 
@@ -24,7 +27,10 @@ backend-shell:
 # ─── Testing ─────────────────────────────────────────────
 
 traceability:
-	python scripts/test/validate_traceability_map.py --map docs/testing/traceability/sample_map.json
+	$(PYTHON) scripts/test/validate_traceability_map.py --map docs/testing/traceability/sample_map.json
+
+validate-claude:
+	./scripts/claude/validate-claude-config.sh
 
 test-backend:
 	PYTHONPATH=apps/backend pytest tests/backend
@@ -53,6 +59,7 @@ SHELL_FILES := .claude/hooks/block-dangerous.sh \
 	.claude/hooks/detect-quality-issues.sh \
 	scripts/bootstrap.sh \
 	scripts/claude/detect-capabilities.sh \
+	scripts/claude/validate-claude-config.sh \
 	scripts/deploy/terraform.sh \
 	scripts/deploy/build-and-deploy.sh \
 	scripts/github/bootstrap-labels.sh

--- a/scripts/claude/validate-claude-config.sh
+++ b/scripts/claude/validate-claude-config.sh
@@ -1,0 +1,361 @@
+#!/usr/bin/env bash
+# validate-claude-config.sh — Claude Code configuration baseline validator
+#
+# Checks:
+#   1. jq availability
+#   2. Required files exist
+#   3. Hooks JSON validity + script existence + exec permissions + settings structure
+#   4. settings.local.json lint (if present)
+#   5. Commands frontmatter (delegated to validate_claude_frontmatter.py)
+#   6. Suspicious invisible Unicode characters
+#
+# Exit codes:
+#   0 — all checks passed (warnings are OK)
+#   1 — one or more checks failed
+#
+# Flags:
+#   --strict    Promote warnings to failures (Phase 6+)
+
+set -uo pipefail
+
+# ─── Globals ─────────────────────────────────────────────
+CLAUDE_DIR=".claude"
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+STRICT=false
+
+# ─── Argument parsing ────────────────────────────────────
+for arg in "$@"; do
+  case "$arg" in
+    --strict) STRICT=true ;;
+    *)
+      echo "Unknown flag: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ─── Helpers ─────────────────────────────────────────────
+
+record() {
+  local status="$1"
+  local message="$2"
+  case "$status" in
+    PASS)
+      echo "  ✅ PASS: $message"
+      PASS_COUNT=$((PASS_COUNT + 1))
+      ;;
+    FAIL)
+      echo "  ❌ FAIL: $message"
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      ;;
+    WARN)
+      if [[ "$STRICT" == "true" ]]; then
+        echo "  ❌ FAIL (strict): $message"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+      else
+        echo "  ⚠️  WARN: $message"
+        WARN_COUNT=$((WARN_COUNT + 1))
+      fi
+      ;;
+  esac
+}
+
+check_file() {
+  local filepath="$1"
+  local label="${2:-$filepath}"
+  if [[ -f "$filepath" ]]; then
+    record PASS "$label exists"
+    return 0
+  else
+    record FAIL "$label is missing"
+    return 1
+  fi
+}
+
+# ─── Check 1: jq availability ───────────────────────────
+check_1_jq() {
+  echo ""
+  echo "Check 1: jq availability"
+  if command -v jq >/dev/null 2>&1; then
+    record PASS "jq is available ($(jq --version 2>&1))"
+  else
+    record FAIL "jq is not installed"
+  fi
+}
+
+# ─── Check 2: Required files ────────────────────────────
+check_2_required_files() {
+  echo ""
+  echo "Check 2: Required files"
+
+  local required_files=(
+    "${CLAUDE_DIR}/settings.json"
+    "${CLAUDE_DIR}/CLAUDE.md"
+    "${CLAUDE_DIR}/commands/README.md"
+    "${CLAUDE_DIR}/rules/README.md"
+    "${CLAUDE_DIR}/skills/README.md"
+  )
+
+  for f in "${required_files[@]}"; do
+    check_file "$f"
+  done
+}
+
+# ─── Check 3: Hooks & settings structure ────────────────
+check_3_hooks_and_settings() {
+  echo ""
+  echo "Check 3: Hooks JSON validity & settings structure"
+
+  local settings="${CLAUDE_DIR}/settings.json"
+
+  # 3a: JSON validity
+  if ! jq empty "$settings" 2>/dev/null; then
+    record FAIL "$settings is not valid JSON"
+    return
+  fi
+  record PASS "$settings is valid JSON"
+
+  # 3b: permissions structure — allow/ask/deny should be arrays
+  for key in allow ask deny; do
+    local ptype
+    ptype=$(jq -r ".permissions.${key} | type" "$settings" 2>/dev/null || echo "null")
+    if [[ "$ptype" == "array" ]]; then
+      record PASS "permissions.${key} is an array"
+    elif [[ "$ptype" == "null" ]]; then
+      record WARN "permissions.${key} is not defined"
+    else
+      record FAIL "permissions.${key} should be an array, got ${ptype}"
+    fi
+  done
+
+  # 3c: hooks structure — PreToolUse and PostToolUse should be arrays
+  for hook_event in PreToolUse PostToolUse; do
+    local htype
+    htype=$(jq -r ".hooks.${hook_event} | type" "$settings" 2>/dev/null || echo "null")
+    if [[ "$htype" == "array" ]]; then
+      record PASS "hooks.${hook_event} is an array"
+    elif [[ "$htype" == "null" ]]; then
+      record WARN "hooks.${hook_event} is not defined"
+    else
+      record FAIL "hooks.${hook_event} should be an array, got ${htype}"
+    fi
+  done
+
+  # 3d: Hook scripts exist and are executable
+  local hook_scripts
+  hook_scripts=$(jq -r '
+    .hooks | to_entries[]
+    | .value[]
+    | .hooks[]
+    | .command
+  ' "$settings" 2>/dev/null || true)
+
+  if [[ -z "$hook_scripts" ]]; then
+    record WARN "No hook scripts defined in settings.json"
+    return
+  fi
+
+  while IFS= read -r script_path; do
+    # Expand $CLAUDE_PROJECT_DIR to current directory
+    local resolved
+    resolved="${script_path//\$CLAUDE_PROJECT_DIR/.}"
+
+    if [[ ! -f "$resolved" ]]; then
+      record FAIL "Hook script not found: $resolved"
+    elif [[ ! -x "$resolved" ]]; then
+      record FAIL "Hook script not executable: $resolved"
+    else
+      record PASS "Hook script OK: $resolved"
+    fi
+  done <<<"$hook_scripts"
+
+  # 3e: Required hook bindings — Bash PreToolUse and Write|Edit PostToolUse
+  local bash_pre
+  bash_pre=$(jq -r '
+    .hooks.PreToolUse // []
+    | map(select(.matcher == "Bash"))
+    | length
+  ' "$settings" 2>/dev/null || echo "0")
+  if [[ "$bash_pre" -gt 0 ]]; then
+    record PASS "Bash PreToolUse hook binding exists"
+  else
+    record WARN "No Bash PreToolUse hook binding found"
+  fi
+
+  local write_post
+  write_post=$(jq -r '
+    .hooks.PostToolUse // []
+    | map(select(.matcher | test("Write|Edit")))
+    | length
+  ' "$settings" 2>/dev/null || echo "0")
+  if [[ "$write_post" -gt 0 ]]; then
+    record PASS "Write/Edit PostToolUse hook binding exists"
+  else
+    record WARN "No Write/Edit PostToolUse hook binding found"
+  fi
+}
+
+# ─── Check 4: settings.local.json ───────────────────────
+check_4_settings_local() {
+  echo ""
+  echo "Check 4: settings.local.json"
+
+  local local_settings="${CLAUDE_DIR}/settings.local.json"
+
+  if [[ ! -f "$local_settings" ]]; then
+    record PASS "settings.local.json not present (OK — optional)"
+    return
+  fi
+
+  if jq empty "$local_settings" 2>/dev/null; then
+    record PASS "settings.local.json is valid JSON"
+  else
+    record FAIL "settings.local.json is not valid JSON"
+  fi
+}
+
+# ─── Check 5: Commands frontmatter ──────────────────────
+check_5_frontmatter() {
+  echo ""
+  echo "Check 5: Commands frontmatter"
+
+  local script_dir
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+  local validator="${script_dir}/validate_claude_frontmatter.py"
+
+  if [[ ! -f "$validator" ]]; then
+    record WARN "validate_claude_frontmatter.py not found, skipping"
+    return
+  fi
+
+  local python_cmd="python3"
+  if ! command -v "$python_cmd" >/dev/null 2>&1; then
+    python_cmd="python"
+  fi
+
+  if ! command -v "$python_cmd" >/dev/null 2>&1; then
+    record WARN "Python not available, skipping frontmatter check"
+    return
+  fi
+
+  local output
+  local exit_code=0
+  if [[ "$STRICT" == "true" ]]; then
+    output=$("$python_cmd" "$validator" --strict 2>&1) || exit_code=$?
+  else
+    output=$("$python_cmd" "$validator" 2>&1) || exit_code=$?
+  fi
+
+  # Print validator output
+  echo "$output" | while IFS= read -r line; do
+    echo "  $line"
+  done
+
+  # Parse Python warning/error counts into shell totals
+  local py_warnings
+  py_warnings=$(echo "$output" | grep ' warnings' | sed 's/.*[^0-9]\([0-9]*\) warnings.*/\1/' | tail -1)
+  py_warnings="${py_warnings:-0}"
+  WARN_COUNT=$((WARN_COUNT + py_warnings))
+
+  if [[ $exit_code -eq 0 ]]; then
+    record PASS "Commands frontmatter validation passed"
+  else
+    record FAIL "Commands frontmatter validation failed"
+  fi
+}
+
+# ─── Check 6: Suspicious Unicode ────────────────────────
+check_6_unicode() {
+  echo ""
+  echo "Check 6: Suspicious invisible Unicode characters"
+
+  # Scan security-sensitive files + prompt files
+  local scan_targets=()
+
+  # settings.json
+  if [[ -f "${CLAUDE_DIR}/settings.json" ]]; then
+    scan_targets+=("${CLAUDE_DIR}/settings.json")
+  fi
+
+  # Hook scripts
+  while IFS= read -r f; do
+    [[ -f "$f" ]] && scan_targets+=("$f")
+  done < <(find "${CLAUDE_DIR}/hooks" -name "*.sh" 2>/dev/null)
+
+  # Prompt files: commands, rules, skills markdown
+  while IFS= read -r f; do
+    [[ -f "$f" ]] && scan_targets+=("$f")
+  done < <(find "${CLAUDE_DIR}/commands" "${CLAUDE_DIR}/rules" "${CLAUDE_DIR}/skills" -name "*.md" 2>/dev/null)
+
+  if [[ ${#scan_targets[@]} -eq 0 ]]; then
+    record WARN "No files to scan for Unicode"
+    return
+  fi
+
+  # Python one-liner to detect suspicious Unicode
+  local python_cmd="python3"
+  if ! command -v "$python_cmd" >/dev/null 2>&1; then
+    python_cmd="python"
+  fi
+
+  if ! command -v "$python_cmd" >/dev/null 2>&1; then
+    record WARN "Python not available, skipping Unicode check"
+    return
+  fi
+
+  local found=0
+  for target in "${scan_targets[@]}"; do
+    local hits
+    hits=$("$python_cmd" -c "
+import sys, re
+# Suspicious Unicode: zero-width chars, directional overrides, homoglyphs
+pattern = re.compile(r'[\u200b-\u200f\u2028-\u202f\u2060-\u2069\ufeff\ufff9-\ufffb]')
+with open(sys.argv[1], 'r', errors='replace') as f:
+    for i, line in enumerate(f, 1):
+        for m in pattern.finditer(line):
+            print(f'{sys.argv[1]}:{i}: U+{ord(m.group()):04X}')
+" "$target" 2>/dev/null || true)
+
+    if [[ -n "$hits" ]]; then
+      found=1
+      while IFS= read -r hit; do
+        record FAIL "Suspicious Unicode: $hit"
+      done <<<"$hits"
+    fi
+  done
+
+  if [[ $found -eq 0 ]]; then
+    record PASS "No suspicious Unicode characters found (${#scan_targets[@]} files scanned)"
+  fi
+}
+
+# ─── Main ────────────────────────────────────────────────
+main() {
+  echo "═══════════════════════════════════════════════════════"
+  echo " Claude Code Configuration Validator (baseline)"
+  if [[ "$STRICT" == "true" ]]; then
+    echo " Mode: STRICT (warnings → failures)"
+  fi
+  echo "═══════════════════════════════════════════════════════"
+
+  check_1_jq
+  check_2_required_files
+  check_3_hooks_and_settings
+  check_4_settings_local
+  check_5_frontmatter
+  check_6_unicode
+
+  echo ""
+  echo "═══════════════════════════════════════════════════════"
+  echo " Results: ✅ ${PASS_COUNT} passed | ❌ ${FAIL_COUNT} failed | ⚠️  ${WARN_COUNT} warnings"
+  echo "═══════════════════════════════════════════════════════"
+
+  if [[ $FAIL_COUNT -gt 0 ]]; then
+    exit 1
+  fi
+  exit 0
+}
+
+main

--- a/scripts/claude/validate_claude_frontmatter.py
+++ b/scripts/claude/validate_claude_frontmatter.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""validate_claude_frontmatter.py — Validate frontmatter in .claude/commands/ files.
+
+Checks that command files have valid YAML frontmatter with expected fields.
+
+Modes:
+  baseline (default): missing frontmatter = warning, broken frontmatter = error
+  --strict:           missing frontmatter = error
+
+Exit codes:
+  0 — all checks passed (warnings OK in baseline mode)
+  1 — one or more errors found
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Frontmatter pattern: match only the first --- ... --- block at file start
+FRONTMATTER_RE = re.compile(r"\A---[ \t]*\n(.*?)\n---[ \t]*\n?", re.DOTALL)
+
+# Fields we check for (informational, not required in baseline)
+RECOMMENDED_FIELDS = {"description", "args"}
+
+
+def parse_frontmatter(content: str) -> tuple[dict | None, str | None]:
+    """Parse YAML frontmatter from file content.
+
+    Returns:
+        (fields_dict, None) on success
+        (None, error_message) on failure
+        (None, None) if no frontmatter present
+    """
+    m = FRONTMATTER_RE.match(content)
+    if not m:
+        return None, None
+
+    yaml_text = m.group(1)
+
+    # Simple key-value parser (avoids PyYAML dependency)
+    fields: dict = {}
+    for line in yaml_text.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        # Remove quotes if present
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        fields[key] = value
+
+    return fields, None
+
+
+def validate_file(filepath: Path, strict: bool) -> tuple[int, int, list[str]]:
+    """Validate a single command file.
+
+    Returns:
+        (errors, warnings, messages)
+    """
+    errors = 0
+    warnings = 0
+    messages: list[str] = []
+
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except Exception as e:
+        messages.append(f"❌ {filepath}: cannot read file: {e}")
+        return 1, 0, messages
+
+    if not content.strip():
+        messages.append(f"⚠️  {filepath}: empty file")
+        return 0, 1, messages
+
+    # Check for frontmatter
+    if not content.startswith("---"):
+        if strict:
+            messages.append(f"❌ {filepath}: no frontmatter (required in strict mode)")
+            errors += 1
+        else:
+            messages.append(f"⚠️  {filepath}: no frontmatter")
+            warnings += 1
+        return errors, warnings, messages
+
+    # Has frontmatter delimiter — try to parse
+    fields, err = parse_frontmatter(content)
+
+    if err:
+        messages.append(f"❌ {filepath}: broken frontmatter: {err}")
+        return 1, 0, messages
+
+    if fields is None:
+        # Started with --- but no closing ---
+        messages.append(f"❌ {filepath}: unclosed frontmatter block")
+        return 1, 0, messages
+
+    # Frontmatter exists and parses — check recommended fields
+    missing = RECOMMENDED_FIELDS - set(fields.keys())
+    if missing:
+        messages.append(
+            f"⚠️  {filepath}: missing recommended fields: {', '.join(sorted(missing))}"
+        )
+        warnings += 1
+    else:
+        messages.append(f"✅ {filepath}: frontmatter OK")
+
+    return errors, warnings, messages
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Claude commands frontmatter")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat missing frontmatter as error",
+    )
+    parser.add_argument(
+        "--dir",
+        default=".claude/commands",
+        help="Directory to scan (default: .claude/commands)",
+    )
+    args = parser.parse_args()
+
+    commands_dir = Path(args.dir)
+    if not commands_dir.is_dir():
+        print(f"❌ Directory not found: {commands_dir}")
+        return 1
+
+    # Find all .md files (excluding README.md)
+    md_files = sorted(
+        f for f in commands_dir.rglob("*.md") if f.name.upper() != "README.MD"
+    )
+
+    if not md_files:
+        print(f"⚠️  No command files found in {commands_dir}")
+        return 0
+
+    total_errors = 0
+    total_warnings = 0
+
+    for filepath in md_files:
+        errs, warns, msgs = validate_file(filepath, strict=args.strict)
+        total_errors += errs
+        total_warnings += warns
+        for msg in msgs:
+            print(msg)
+
+    print(
+        f"\nFrontmatter: {len(md_files)} files checked, "
+        f"{total_errors} errors, {total_warnings} warnings"
+    )
+
+    return 1 if total_errors > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 概要

baseline 版の Claude 設定バリデーター（6 Check）と frontmatter バリデーターを追加し、CI の `docdd-validation` job で DocDD トレーサビリティ検証と合わせて実行する。

## 関連 Issue

Closes #27
Parent Epic: #23

## 変更点

### 新規ファイル
- **`scripts/claude/validate-claude-config.sh`** — baseline validator（6 Check）
  - Check 1: jq 可用性
  - Check 2: 必須ファイル存在（settings.json, CLAUDE.md, 3 README）
  - Check 3: hooks JSON validity + settings 構造（permissions/hooks 配列性）+ スクリプト存在・実行権限
  - Check 4: settings.local.json lint（存在時のみ）
  - Check 5: commands frontmatter（Python validator 委譲）
  - Check 6: 疑わしい不可視 Unicode 文字検査
  - `--strict` フラグ土台（Phase 6 で有効化予定）

- **`scripts/claude/validate_claude_frontmatter.py`** — frontmatter validator
  - baseline: frontmatter なし = warning、壊れている = error
  - `--strict`: frontmatter なし = error に昇格

### 変更ファイル
- **`Makefile`** — `PYTHON ?= python3` 導入、`validate-claude` target 追加、`traceability` target を `$(PYTHON)` に変更、`SHELL_FILES` に新規 .sh 追加
- **`.github/workflows/docdd-starters-ci.yml`** — `docdd-validation` job 新設（Python 3.11 + jq）

## 設計判断

### baseline / strict 二段階設計（ADR）
docdd-starters はテンプレートプロジェクトのため、strict モードをデフォルトにすると fork 直後に CI が赤になる。baseline モードで最小限の検証を行い、Phase 6 で strict 化する。

## 検証結果

- [x] `/5` で検証済み（[コメント](https://github.com/syotakokichi/docdd-starters/issues/27#issuecomment-4236664703)）
- [x] マルチレビュー実施（R1: Codex gpt-5.4 / R2: Claude SA / R3: Claude SA）
- [x] R1 発見の 2 件のバグを修正済み:
  - frontmatter regex: EOF trailing newline なしの edge case
  - warning count: Python validator の警告を shell summary に反映
- [x] `make validate-claude` PASS（20 passed, 0 failed, 16 warnings）
- [x] `make traceability` PASS
- [x] `make shell-lint` / `make shell-format-check` PASS
- [x] CLAUDE.md 更新チェック済み（更新不要）


🤖 Generated with [Claude Code](https://claude.com/claude-code)