### PR TITLE
feat(harness): canonical command skeleton (issue/worktree/plan/develop/verify) — Phase 2-1

### DIFF
--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -1,0 +1,249 @@
+---
+description: GitHub Issue の実装を行います。
+argument-hint: "<issue-number>"
+disable-model-invocation: true
+---
+GitHub Issue $ARGUMENTS の実装を行ってください。
+
+**CLAUDE.md の開発フローに従って進めてください。**
+
+---
+
+## 手順
+
+### Phase 1: 準備
+
+1. `gh issue view $ARGUMENTS --comments` で Issue の内容を確認
+   - `[実装計画]` がタイトルにあれば、計画に従って実装
+   - なければ先に `/plan $ARGUMENTS` で計画を立てる
+
+2. **Issue を「進行中」に設定**:
+   ```bash
+   gh issue edit $ARGUMENTS --remove-label "status:todo" --add-label "status:in-progress" 2>/dev/null || true
+   ```
+
+3. **適用スキルを読み込む**（Issue の内容に応じて選択）:
+
+   | Issue involves... | Applicable Skill | Path |
+   |-------------------|------------------|------|
+   | Backend API / FastAPI | backend-patterns | `.claude/skills/backend-patterns/SKILL.md` |
+   | Frontend / Next.js / UI | frontend-patterns | `.claude/skills/frontend-patterns/SKILL.md` |
+   | Test implementation | testing-patterns | `.claude/skills/testing-patterns/SKILL.md` |
+   | DocDD documents / 7-axis | docdd-workflow | `.claude/skills/docdd-workflow/SKILL.md` |
+
+4. **TDD 証跡を確認する**（`/plan` 検証定義の「TDD 判定」欄）:
+   - `TDD 必須` → RED テストを先行作成して FAILED 結果を確認してから実装へ
+   - `TDD スキップ（理由あり）` → スキップ理由をサマリに転記して実装へ
+   - 空欄 → **証跡漏れ** として判断を明示してから実装へ
+
+> 後続 Issue で TDD 専用コマンド `/tdd` および `.claude/rules/tdd-gate.md` を導入予定。本コマンドでは TDD 必須判定の場合も `/develop` 内で RED → GREEN を進める。
+
+### Phase 2: 実装
+
+1. コードベースを調査し、関連ファイルを特定
+2. 計画に基づいて実装を進める（TDD 対象は RED 確認済みの前提）
+3. GREEN にする最小実装を書く
+
+> **Note**: UI 設計（Pencil）の確認は `/plan` Phase 1.5 で完結済みの想定。`/develop` では計画で確認済みのデザインを正として進める（`.claude/rules/project-workflow.md` 参照）。
+
+> **バグ修正時**: 原因調査に行き詰まったら、変更対象を最小化し、再現テストを書いてから修正する。
+
+#### チーム活用（2 レイヤー以上の変更時）
+
+変更対象が 2 レイヤー以上にまたがり、かつファイル競合が少ない場合はエージェントチームを組成する。単一レイヤーの変更では従来通り単一セッションで実装する。
+
+| 条件 | モード |
+|------|--------|
+| 単一レイヤーの変更 | 単一セッション（従来通り） |
+| 2 レイヤー以上 + ファイル競合なし | エージェントチーム |
+
+詳細: `.claude/rules/agent-teams.md`
+
+チーム構成例:
+```
+Issue #XXX をチームで実装して。
+- Backend担当: API + サービス層（apps/backend/app/modules/<module>/）
+- Frontend担当: 画面（apps/frontend/app/<segment>/）
+- テスト担当: 統合テスト + DocDD 更新
+```
+
+### Phase 2.5: DocDD 更新（実装と同じ Issue 内で）
+
+実装が完了したレイヤーに応じて、関連する DocDD ドキュメントを更新する。
+**後回し禁止** — 実装の記憶が新しいうちに書く。
+
+| 実装内容 | 更新対象 |
+|---------|---------|
+| DB モデル追加/変更 | `docs/7-axis/3_DM/DM-*.md` |
+| API エンドポイント追加 | `docs/7-axis/6_API/<domain>/*.yaml` |
+| UI 画面追加/変更 | `docs/7-axis/2_UC/` / `docs/7-axis/4_SR/`（該当あれば） |
+| テスト追加 | `docs/7-axis/7_TC/TC-*.yaml` + `docs/testing/traceability/<domain>_map.json` |
+
+**判断基準:**
+- 新規モデル / エンドポイント → **必ず更新**
+- 既存の軽微な修正（バグ修正等） → 更新不要
+- サイズ上限（20 ファイル）を超えそうな場合 → DocDD を別 Issue に分割
+
+詳細: `.claude/rules/project-workflow.md` の「DocDD 更新ルール」
+
+### Phase 3: 品質チェック（変更箇所に応じて実行）
+
+実装完了後、**変更した箇所に応じて** 品質チェックを実行する。
+
+#### 変更レイヤーごとの必須チェック
+
+| 変更レイヤー | コマンド |
+|------------|---------|
+| Backend のみ | `make test-backend` |
+| Frontend のみ | `make test-frontend` |
+| Backend + Frontend | `make test`（両方を実行） |
+| `.claude/commands/`, `.claude/templates/`, `.claude/skills/`, `.claude/rules/`, `.claude/references/` | `make validate-claude` |
+| `docs/7-axis/`, `docs/testing/traceability/` | `make traceability` |
+| API 契約変更（request / response / status code） | OpenAPI yaml 更新確認 + caller 全件確認 + request/response 整合性 |
+| 状態管理変更（Zustand / URL param / form restore） | 保存・復元・戻る導線・次画面の確認 |
+| 画面遷移変更 | 対象導線を入口から完了まで確認 |
+
+#### 実行ルール
+
+- **Backend を触ったら** `make test-backend` だけで終わらせず、変更したモジュールに紐づく focused pytest（`pytest apps/backend/tests/.../test_xxx.py::test_name`）も実行する
+- **API 契約を変えたら**、client / hook / container / 次画面 / callback handler まで追って確認する
+- **DocDD を更新したら** `make traceability` を実行する
+- **`.claude/` の dx-docs を変更したら** `make validate-claude` を実行する
+- ブラウザ結合確認は `/verify` で軽量ヘルスチェック（Console / Network エラーチェック）として実施する
+
+#### 失敗扱いにするもの
+
+- `0 selected`
+- `all skipped`
+- `script not found`
+- `make test-backend` / `make test-frontend` / `make test` / `make validate-claude` / `make traceability` が FAIL
+- 実行コマンド未記録
+
+### Phase 4: 高リスク変更の確認（該当時のみ）
+
+**原則**: ブラウザ結合確認・統合的な動作確認は `/verify` の軽量ヘルスチェックで実施する。
+`/develop` では **高リスク変更のみ** 追加の事前確認（pre-merge stg 実確認等）を行う。
+
+#### 高リスク変更の定義
+
+以下に該当する導線は、PR マージ前に追加の事前確認を行う:
+
+| 対象 | 例 | 根拠 |
+|------|-----|------|
+| 決済 | 課金処理、金額計算、外部決済連携 | 二重課金・決済失敗の顧客影響が大きい |
+| 認証 | ログイン、トークン管理、招待トークン、パスワードリセット | ロックアウト・不正アクセスの顧客影響が大きい |
+| 外部連携 | 外部 API への送受信、Webhook、コールバック | ローカルでは疎通不可。STG 実確認が必要 |
+| マイグレーション | DB スキーマ変更、データ移行 | 後方互換性の破綻・データ損失リスク |
+| 状態遷移 | 申込・解約・契約変更等の主要導線 | 不整合状態の発生リスク |
+| IP 制限 / Secrets 依存 | ホワイトリスト、Secrets Manager 依存画面 | ローカルでは再現不可能 |
+
+#### 実施手順（high-risk のみ）
+
+1. **検証に必要なコード差分を main に持っていく**（worktree から差分を確認、必要なら main checkout で再現）
+2. **ステージング環境を検証可能な状態にする**:
+   - Backend 変更あり: `make deploy-stg` でステージングへデプロイ
+   - マイグレーションあり: ステージング DB へ migration を適用
+   - Frontend 変更あり: `make deploy-stg` でステージングへデプロイ
+3. **ステージングで主要導線を最後まで確認する**:
+   - 正常系の入口 → 完了
+   - 主要な異常系（外部 API エラー、認証失敗、入力不正）
+4. **証跡を残す**（実行コマンド + 結果 + スクリーンショット）。後続の `/verify` Step 5 で参照する
+
+#### FAIL 時の復旧フロー
+
+1. **worktree に戻って修正する**: `cd .claude/worktrees/issue-<N>` → 原因を特定して修正
+2. **ステージングを再デプロイ**: 上記 Step 2-3 を再実行
+3. **再確認**: 上記 Step 3-4 を再実行
+4. **復旧サイクル上限**: Step 1〜3 の再試行は **最大 3 回** まで。3 回再試行しても解消しない場合はユーザーに判断を仰ぐ（根本原因の再調査 / Issue 分割 / 一旦マージ見送り等）
+
+#### デフォルト経路（高リスク変更に該当しない場合）
+
+- `/verify` Step 4 のブラウザヘルスチェック（Console / Network / 主要導線手動確認）に委譲する
+- 実装サマリーのブラウザ確認欄は `Deferred to /verify` と記録する
+
+> **例外を増やさない原則**: 上記以外の「ステージングでないと確認できない」は `/verify` で十分。迷ったらデフォルト経路（`Deferred to /verify`）を選ぶ。
+
+### Phase 5: 実装サマリー（`/verify` への引き継ぎ）
+
+Phase 3 / 4 完了後、**実装内容を `gh issue comment $ARGUMENTS` で Issue コメントとして投稿**する。
+`/verify` で事実確認を行う際の基準資料となる。
+
+- 構成は `.claude/templates/implementation-summary-comment.md` に従う（**見出し・TDD 判定行・Coverage 結果行の記法を厳守**）
+  - 見出し: `## 実装サマリー（/develop 完了時点）` をそのまま使う
+  - TDD 判定行: スキップ時は `スキップ（理由: ...）` と同一セル内に書く
+  - Coverage 結果行: `PASS` / `N/A` / `未解消` のみ（装飾なし）
+- `ブラウザ確認` は `Deferred to /verify` / `PASS`（高リスク変更の事前確認済み）/ `N/A` のいずれかで必ず埋める
+- **`TDD 証跡` を必ず埋める**（必須 / スキップ（理由）のどちらかで空欄禁止）
+- **`Coverage 証跡` を必ず埋める**（`/plan` の Critical Path テーブルから転記 + focused test の実行結果を記録）
+- `未解消` が残る場合は理由と扱いを明記する
+
+#### 計画との差分があれば Issue 本文を更新
+
+実装中に当初計画と異なる選択をした場合、追加の決定事項が出た場合、予期しない問題が発生した場合は Issue 本文も更新する:
+
+```bash
+gh issue edit $ARGUMENTS --body-file /tmp/issue_$ARGUMENTS.md
+```
+
+または `/update-issue` を使用する。
+
+---
+
+## チェックリスト
+
+品質チェック通過後に確認:
+
+- [ ] 変更レイヤーに対応する `make test-backend` / `make test-frontend` / `make test` のいずれかが PASS している
+- [ ] `.claude/` の dx-docs を変更した場合は `make validate-claude` が PASS している
+- [ ] DocDD を更新した場合は `make traceability` が PASS している
+- [ ] `0 selected` / `all skipped` / `script not found` を成功扱いにしていない
+- [ ] **TDD 対象の場合: RED コマンドの FAILED 結果と GREEN コマンドの PASSED 結果が記録されている**
+- [ ] **TDD スキップの場合: スキップ理由が明記されている（空欄 = 証跡漏れ）**
+- [ ] API 契約変更時は caller と次画面まで確認した
+- [ ] 高リスク変更（決済 / 認証 / マイグレーション / 外部連携）がある場合は Phase 4 の事前確認を済ませた
+- [ ] Phase 5 の実装サマリーを Issue コメントに投稿した
+- [ ] 計画との差分があれば Issue 本文を更新した
+
+---
+
+## 次のステップ
+
+実装サマリー投稿後、ユーザーに以下を案内する:
+
+```
+Issue #<N> 実装完了:
+  - 変更ファイル: N 件
+  - TDD 証跡: 必須-PASS / スキップ（理由）
+  - Coverage: PASS / N/A
+  - 計画との差分: あれば 1 行 / なし
+
+次のステップ:
+  /verify <N>     # 別セッションで実行（確証バイアス回避）
+```
+
+> **新しいセッションで `/verify` を実行する理由**: 実装者の文脈（編集したファイル・意図）が残ったまま検証すると見落としが増える。新セッションで `/verify` を起動することで、フレッシュな目で事実確認できる。
+
+---
+
+## 注意事項
+
+- 計画（`[実装計画]`）がなければ先に `/plan` を実行
+- 品質チェックは変更箇所に応じて実行する（全レイヤー網羅でなくて OK）
+- ブラウザ結合確認は原則 `/verify` に委譲する。高リスク変更（決済 / 認証 / マイグレーション / 外部連携）のみ `/develop` 内で事前確認する
+- 大きな変更があれば Issue 本文を更新する
+
+---
+
+## 📋 後続 Issue で導入予定（forward reference の隔離）
+
+| 参照先（未存在） | 用途 | 予定 Issue |
+|--------------|------|----------|
+| `/tdd` コマンド | TDD 専用コマンド（RED テスト先行作成） | 後続 Issue（4-2 想定） |
+| `.claude/rules/tdd-gate.md` | TDD 判定の SSOT | 後続 Issue（4-2 想定） |
+| `.claude/skills/tdd-workflow/SKILL.md` | TDD 実行スキル | 後続 Issue（4-2 想定） |
+| `.claude/skills/systematic-debugging/SKILL.md` | バグ修正の体系化スキル | 後続 Issue（4-3 想定） |
+| `.claude/skills/verification-before-completion/SKILL.md` | 完了主張前のゲート | 後続 Issue（4-2 想定） |
+| `make quality-gate` ターゲット | 品質ゲート一括実行 | 後続 Issue（5-1 想定） |
+| `/screen-verify` + TC YAML 自動実行 | post-merge ステージング検証 | 後続 Issue（D-X 想定） |
+
+Remember to use the GitHub CLI (`gh`) for all GitHub-related tasks.

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,142 @@
+---
+description: 新しい GitHub Issue を作成します。
+disable-model-invocation: true
+---
+新しい GitHub Issue を作成してください。canonical workflow の起点となるコマンドです。
+
+**CLAUDE.md の開発フローに従って進めてください。**
+
+---
+
+## 役割
+
+- 新しい GitHub Issue を作成する
+- サイズチェックでスコープが適切に切れているか確認する
+- 次に進むべきフェーズ（`/worktree` → `/plan`）を案内する
+
+## 使い方
+
+- 新規作業を起票する場合は `/issue`
+- やりたいことが曖昧なら `/discuss` で壁打ちしてから `/issue`
+- 既存 Issue の本文更新は `/update-issue` を使用する
+
+タスクの内容を伝えてください。以下の情報があると良いです:
+
+- 何を実現したいか
+- 背景や理由
+- 完了条件
+
+## 次のステップ
+
+Issue 作成後の正規フロー:
+
+```
+/worktree <N>     # worktree 作成 + ブランチ命名（推奨。詳細は parallel-development スキル参照）
+/plan <N>         # Issue 本文に仕様固定済みの計画を反映
+```
+
+---
+
+## 手順
+
+### Step 1: サイズチェック
+
+Issue の概要から影響範囲を概算し、`.claude/rules/issue-sizing.md` に照らす:
+
+| 指標 | 上限 |
+|------|:----:|
+| 変更対象ファイル | 20 |
+| 実装タスク数 | 8 |
+| 起因 Issue / 負債 | 1 |
+| Phase 数 | 1 |
+
+**超過しそうな場合**: 縦スライス（ドメイン概念ごと）に分割して複数 Issue を作成する。
+特に「負債まとめて返済」パターンは禁止。棚卸し Issue + 個別 Issue に分ける。
+
+### Step 2: Issue 作成
+
+```bash
+gh issue create --title "[タイトル]" --body "$(cat <<'EOF'
+# Issue: [タイトル]
+
+## 背景
+[なぜ必要か]
+
+## 目的
+[何を実現したいか]
+
+## 受け入れ条件
+- [ ] [どうなれば完了か]
+EOF
+)"
+```
+
+### Step 3: ラベル付与（最低 2 つ）
+
+`.github/labels.json` で管理されている canonical labels を **第一候補** として提示し、必要に応じて legacy alias も使用可（移行期間中の互換性確保のため）。
+
+#### 優先度（1 つ選択）— canonical 優先
+
+| canonical | legacy alias | 用途 |
+|-----------|--------------|------|
+| `P0` | `High` | 1〜2 営業日以内に対応すべき緊急タスク |
+| `P1` | `Medium` | 通常の機能追加やバグ修正 |
+| `P2` | `Low` | 将来的に対応で良い小変更 |
+
+#### 領域（1 つ以上選択）— canonical 優先
+
+| canonical | legacy alias | 用途 |
+|-----------|--------------|------|
+| `BE` | `バックエンド` | API・サーバーサイド実装 |
+| `FE` | `フロントエンド` | UI/UX 実装・修正 |
+| `infra` | `インフラ` | インフラ基盤・CI/CD |
+| `docs` | `ドキュメント` | ドキュメント作成・更新 |
+| `tests` | `テスト` | テストコードの追加・修正 |
+| `bug` | `バグ` | 不具合修正 |
+| `chore` | （なし） | ビルド・依存・メタ作業 |
+
+#### ステータス
+
+- `status:todo` を初期付与（`/develop` で `status:in-progress`、`/7` 系で `status:done` に遷移）
+
+#### 適用例
+
+```bash
+# canonical（推奨）
+gh issue create --title "..." --body "..." --label "P1" --label "BE" --label "status:todo"
+
+# legacy alias（移行期間中の互換性）
+gh issue create --title "..." --body "..." --label "Medium" --label "バックエンド" --label "status:todo"
+```
+
+> ラベル整合の詳細は `.github/labels.json` を参照。canonical / legacy alias どちらでマージされても動作するよう、両方のラベルが定義されている。
+
+### Step 4: 後続フローの案内
+
+Issue 番号を控えて、ユーザーに次のステップを案内する:
+
+```
+Issue #<N> 作成完了
+
+次のステップ:
+  /worktree <N>   # worktree 作成 + ブランチ命名（推奨）
+  /plan <N>       # 実装計画立案
+```
+
+---
+
+## 注意事項
+
+- Issue 作成後、`/plan` で実装計画を立案して Issue 本文に追記する
+- 並列開発する場合は `/worktree <N>` を先に実行し、worktree 内で `/plan` 〜 `/6` を進める
+- 単独 sequential で進める場合は `/plan` 直後に `/develop` でも可（`.claude/skills/parallel-development/SKILL.md` 参照）
+
+---
+
+## 📋 後続 Issue で導入予定（forward reference の隔離）
+
+| 参照先（未存在） | 用途 | 予定 Issue |
+|--------------|------|----------|
+| `/brainstorm` コマンド | 曖昧な要望から Issue 化前のアイデア出し | 後続 Issue（2-2 想定） |
+
+Remember to use the GitHub CLI (`gh`) for all GitHub-related tasks.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,297 @@
+---
+description: GitHub Issue の仕様固定済み実装計画を作成します。
+argument-hint: "<issue-number>"
+disable-model-invocation: true
+---
+GitHub Issue $ARGUMENTS の仕様固定済み実装計画を作成してください。
+
+**時間をいくらかけてもいいので品質を優先してください。**
+**リサーチして公式のベストプラクティスがあれば採用してください。**
+**CLAUDE.md の開発フローに従って進めてください。**
+
+---
+
+## 前提
+
+- Issue が作成済み（`/issue` で起票するか、既存の Issue を対象とする）
+- 標準では `/worktree $ARGUMENTS` 後に実行する（worktree 内で計画立案 → 実装 → 検証 → PR 作成）
+
+## このコマンドの完了条件
+
+Issue 本文が「実装可能」ではなく、**仕様固定済み** になっていること。
+
+最低限、以下が Issue 本文に残っていること:
+
+- 影響範囲（依存先・波及範囲・DocDD 更新対象）
+- 証跡マッピング表
+- サイズチェック
+- 重要ポイント
+- 実装タスク
+- 検証定義（V1 + Issue 固有の V3 以降）
+- TDD 判定
+- Critical Path / Coverage expectation
+
+> ⚠️ **Plan mode を使用している場合**: ExitPlanMode を呼ぶ前に必ず `gh issue edit` で Issue 本文を更新してください。Plan mode を抜けてから Issue 更新すると、会話内容が失われる場合があります。
+
+## 次のステップ
+
+### Worktree の要否（必ず言及すること）
+
+計画完了時に worktree の要否を明示する。**原則 worktree 推奨**（Track 問わず）。
+
+判定 SSOT: [.claude/skills/parallel-development/SKILL.md](../skills/parallel-development/SKILL.md) 「判定 SSOT — 原則 worktree 推奨」。Track A/B は `.env` 要否の分類にのみ使用し、worktree 要否とは独立。
+
+| 状況 | 案内 |
+|------|------|
+| デフォルト（複数エディタ並走 / 他セッションと並列） | `/worktree <N>` を推奨 |
+| 例外: 単独 sequential を明示（ユーザー自己申告） | main 直接作業も可（ただし worktree 推奨の旨は案内） |
+
+例外の発動条件は SKILL.md「例外トリガー（ユーザー自己申告の substring 一致）」セクションを参照（SSOT）。`/plan` を呼んだ **直前のユーザー発話** に substring（「単独 sequential」「sequential mode」「worktree なし」等）が含まれない限り、常に worktree 推奨に倒す。
+
+**出力例（デフォルト・次のステップ — `/plan` 完了時点）:**
+```
+/develop <N>
+/verify <N>
+/6
+```
+
+> worktree は `/plan` の前段（`/worktree <N>`）で作成済みのはず。`/plan` が main で実行された場合は、以降の `/develop` / `/verify` / `/6` を worktree で実行するため先に `/worktree <N>` を案内する（`/plan` 自体の再実行は不要）。
+
+---
+
+## 手順（段階的に進める）
+
+**重要: このコマンドの最終ゴールは「Issue本文の更新」です。**
+**フロー**: Phase 0-3（調査・相談・リサーチ）→ Phase 4（Issue 更新）→ Phase 5（Codex 計画レビュー + Issue コメント記録）
+
+### Phase 0: Issue ステータス確認
+
+```bash
+gh issue view $ARGUMENTS --json title,body,labels,state
+```
+
+- `[実装計画]` がタイトルに既に付いている場合は再計画として扱い、既存の計画と差分を取る
+- ラベルに `status:todo` / `status:in-progress` のいずれかがあるか確認（なければ Phase 4 で `status:todo` を付与）
+
+### Phase 1: 理解
+
+1. `gh issue view $ARGUMENTS --comments` で Issue の内容と既存コメントを確認
+2. **適用スキルを読み込む**（Issue の内容に応じて選択）:
+
+   | Issue involves... | Applicable Skill | Path |
+   |-------------------|------------------|------|
+   | Backend API / FastAPI | backend-patterns | `.claude/skills/backend-patterns/SKILL.md` |
+   | Frontend / Next.js / UI | frontend-patterns | `.claude/skills/frontend-patterns/SKILL.md` |
+   | Test implementation | testing-patterns | `.claude/skills/testing-patterns/SKILL.md` |
+   | DocDD documents / 7-axis | docdd-workflow | `.claude/skills/docdd-workflow/SKILL.md` |
+   | UI design / デザイントークン | design | `.claude/skills/design/SKILL.md` |
+
+3. **品質ルール** `.claude/rules/planning-quality.md` を参照
+4. コードベースを調査し、影響範囲を特定
+   - **変更起点ごとに依存先をトレースすること**（API → schema → repo → caller、UI → container → hook → API）
+   - 同じドメインの既存 Issue を `gh issue list --label <label> --state open` で確認
+
+### Phase 1.2: 依存先・呼び出し元トレース（必須）
+
+影響範囲の特定後、**変更起点から下流まで閉じているか** を確認する。
+
+- 変更起点ごとに、波及先（caller、UI、状態管理、テスト）を Issue 本文の表に列挙する
+- 「直接実装しないが壊していないことを確認すべき箇所」も別表に明記する
+
+### Phase 1.2.5: 証跡マッピング表 + UI State Matrix（必須）
+
+Phase 1.2 の依存先トレースが完了した時点で、変更パスから必要な証跡を特定する。
+
+1. `.claude/templates/issue-implementation-plan.md` の「🗺️ 証跡マッピング表」を全行コピーし、各行を ✅（該当）または —（非該当）で埋める
+2. UI 変更がある場合は「🖥️ UI State Matrix」を埋める。UI 変更がなければ「UI 変更なし — 適用外」と記載
+3. ブラウザ確認が必要な場合は、TC YAML の作成タスクを実装タスクに含めるか検討する（`docs/7-axis/7_TC/`）
+4. DocDD 更新を伴う場合は、関連する `docs/7-axis/` のドキュメントパス（DM / API / UC / SR / TC）を実装タスクに列挙し、`make traceability` を検証定義 V2 に含める
+5. テスト追加・契約変更がある場合は、変更レイヤーに応じた `make test-backend` / `make test-frontend` / `make test` を Critical Path テーブルの focused test commands に記入する
+
+### Phase 1.3: Critical Path 判定（必須）
+
+変更対象を以下の基準で評価する:
+
+- **Critical**: 状態遷移・外部連携・callback・認証・申込導線を含む
+- **Non-critical**: 上記に該当しない（UI 文言、CSS、DX ツーリング等）
+- **Mixed**: Critical と Non-critical が混在
+- **N/A**: `.claude/` / `docs/` のみの変更、文言修正のみ
+
+判定結果に応じて Coverage expectation・focused test commands を Issue 本文の Critical Path テーブルに記入する。
+
+### Phase 1.5: UI 設計の確認（UI 変更を伴う場合）
+
+UI 変更を伴う Issue の場合は、計画前にデザインを検討:
+
+- `.claude/skills/design/SKILL.md` を参照（Pencil.dev MCP 連携によるデザイントークン管理・コンポーネント設計）
+- デザインが確定したら Issue にモックアップ URL や Pencil 画面 ID を添付
+- コンポーネント分割を計画に含める
+
+> **理由**: 設計を `/develop` に先送りすると、修正中の発見で計画変更が必要になり手戻りが発生する。`.claude/rules/project-workflow.md` の「Pencil 調整ルール」を参照。
+
+### Phase 1.6: サイズチェック（必須）
+
+影響範囲の特定後、`.claude/rules/issue-sizing.md` に照らしてサイズチェックを行う:
+
+| 指標 | 上限 |
+|------|:----:|
+| 変更対象ファイル | 20 |
+| 実装タスク数 | 8 |
+| 起因 Issue / 負債 | 1 |
+| Phase 数 | 1 |
+| API/型の契約変更点 | 3 |
+| 下流呼び出し元数 | 5 |
+
+**2 つ以上 ❌ の場合**: 分割案をユーザーに提示してから計画を進める。
+分割の方針: ドメイン概念ごとの縦スライスを優先。
+
+### Phase 2: ユーザーと相談（必須）
+
+**計画を確定する前に、必ずユーザーと方向性を相談してください。**
+
+相談すべき内容:
+- 実装アプローチの選択肢（複数ある場合）
+- 技術的なトレードオフ
+- 優先順位の確認
+- 不明点の確認
+- 後続 Issue の見通し（Backend → Frontend → DocDD 等、複数段階になる場合）
+
+```
+例: 「Issue #XX について調査しました。
+実装方針として A と B の選択肢があります。
+A: [メリット/デメリット]
+B: [メリット/デメリット]
+どちらで進めますか？」
+```
+
+### Phase 3: リサーチ（必要時）
+
+- 公式ドキュメントやベストプラクティスをリサーチ
+- **参照した外部リンクは必ず記録**（後で Issue 本文に追記）
+- アーキテクチャ決定がある場合は ADR セクションを準備
+- 新機能の場合は DocDD 7 軸トレーサビリティ文書計画を準備
+
+**エージェントチーム活用**（複雑な Issue の場合）:
+- 複数ドメインにまたがる場合は、並列リサーチエージェントで調査を効率化
+- 技術選定では、複数候補を並列で調査し比較検討
+- 詳細は `.claude/rules/agent-teams.md` のパターン 1（並列リサーチ）・パターン 10（Issue 分析・計画）を参照
+
+### Phase 4: Issue 更新（必須）
+
+1. **`gh issue edit` で Issue 本文に計画を追記**（テンプレート: `.claude/templates/issue-implementation-plan.md`）
+2. **`gh issue edit --title` でタイトルに `[実装計画]` を追加**
+3. **ラベル付与**（最低 2 つ。canonical 優先 — `.github/labels.json` 参照）:
+   - 優先度: `P0` / `P1` / `P2`（legacy alias: `High` / `Medium` / `Low`）
+   - 領域: `BE` / `FE` / `infra` / `docs` / `tests` / `bug` / `chore`（legacy alias: `バックエンド` / `フロントエンド` / `インフラ` / `ドキュメント` / `テスト` / `バグ`）
+   - ステータス: `status:todo` または `status:in-progress`
+
+#### 長い計画の場合
+
+```bash
+# 1. 一時ファイルに書き出し
+cat > /tmp/issue_$ARGUMENTS.md << 'EOF'
+[既存の内容 + 計画]
+EOF
+
+# 2. Issue 更新
+gh issue edit $ARGUMENTS --body-file /tmp/issue_$ARGUMENTS.md
+```
+
+### Phase 5: Codex 計画レビュー
+
+Issue 本文更新後、Codex CLI で計画テキストをレビューする。
+ルール参照: `.claude/rules/codex-review.md`
+
+> ⚠️ **`/plan` と `/verify` では Codex への渡し方が異なる**
+> - `/plan`: **計画テキスト**のレビュー（Issue 本文）→ `--base main` は使わない
+> - `/verify`: **コード差分**のレビュー → `--base main` を使う
+>
+> `/plan` で `codex review --base main` を実行すると、ワーキングツリーの差分がレビューされ、当該 Issue の計画が検証されない。
+
+#### Codex 利用可否を判定
+
+```bash
+codex --version > /dev/null 2>&1
+```
+
+#### Codex が利用可能な場合
+
+1. 計画テキストを一時ファイルに書き出し:
+   ```bash
+   gh issue view $ARGUMENTS --json body -q '.body' > /tmp/issue_$ARGUMENTS.md
+   ```
+
+2. プロンプトテンプレートと結合して Codex に投入:
+   ```bash
+   cat .claude/templates/codex-plan-review-prompt.md /tmp/issue_$ARGUMENTS.md > /tmp/codex_prompt_$ARGUMENTS.md
+   codex exec "$(cat /tmp/codex_prompt_$ARGUMENTS.md)"
+   ```
+
+   > **注意**: Codex の応答には 3〜5 分かかる場合がある。30 秒で応答なしと判定しないこと。
+
+3. 結果を Issue コメントに記録:
+   ```bash
+   gh issue comment $ARGUMENTS --body "## 計画レビュー結果（/plan Phase 5 — Codex CLI）
+
+   <レビュー結果をここに記載>
+
+   ---
+   *Codex CLI review: $(date +%Y-%m-%d)*"
+   ```
+
+4. **指摘の分類と対応** （`.claude/rules/codex-review.md` 参照）:
+   - 🔴 必須: 計画に影響する見落とし・不整合 → 計画を修正して Issue 本文を再更新
+   - 🟡 推奨: 計画の改善提案 → 実装タスクに追加 or 注意事項として記載
+   - 🟢 参考: 記録のみ
+   - ❌ 却下: 理由を付けて却下
+
+#### Codex が利用不可の場合（Fallback）
+
+**サイレントスキップ禁止** — 必ずユーザーに通知する。
+
+1. `.claude/templates/codex-review-handoff.md` の「計画レビュー」セクションを出力
+2. ユーザーに手動で Codex / ChatGPT にレビューを依頼するよう案内
+
+```
+⚠️ Codex CLI が未導入のため、計画レビューを自動実行できません。
+以下の handoff テンプレートを使って手動レビューを実施してください。
+```
+
+> **後続 Issue で Codex + Claude SA × 2 の 3 reviewer 並列レビュー（multi-model-review）を導入予定**。本コマンドでは Codex 単独レビューに留める。
+
+---
+
+## 参照テンプレートとリファレンス
+
+- Issue 本文テンプレート: `.claude/templates/issue-implementation-plan.md`
+- Codex レビュープロンプト: `.claude/templates/codex-plan-review-prompt.md`
+- Codex レビュー引き継ぎテンプレート: `.claude/templates/codex-review-handoff.md`（Codex CLI 未導入時のフォールバック）
+- Codex CLI レビュー運用ルール: `.claude/rules/codex-review.md`
+- 計画品質ルール: `.claude/rules/planning-quality.md`
+- サイジングルール: `.claude/rules/issue-sizing.md`
+- Pencil 調整ルール: `.claude/rules/project-workflow.md`
+- 並列開発判定 SSOT: `.claude/skills/parallel-development/SKILL.md`
+
+---
+
+## 注意事項
+
+- **一気に進めず、Phase 2 でユーザーと相談すること**
+- **Phase 5 で Codex 計画レビューを必ず実施する**（`.claude/rules/codex-review.md` 参照）
+- コメントではなく **Issue 本文を編集** して計画を追記
+- 元の Issue 内容は残す
+- スキルファイルのパターン・制約に従う
+
+---
+
+## 📋 後続 Issue で導入予定（forward reference の隔離）
+
+| 参照先（未存在） | 用途 | 予定 Issue |
+|--------------|------|----------|
+| `.claude/rules/multi-model-review.md` | Codex + Claude SA × 2 の 3 reviewer 並列レビュー | 後続 Issue（D-1 想定） |
+| `.claude/skills/test-design/SKILL.md` | Critical Path 判定スキル化 | 後続 Issue（4-2 想定） |
+| `.claude/rules/tdd-gate.md` | TDD 判定の SSOT | 後続 Issue（4-2 想定） |
+| `.claude/references/applicable-skills.md` | 適用スキル一覧の SSOT | 後続 Issue（4-1 想定） |
+| `.claude/skills/planning-quality/SKILL.md` | `rules/planning-quality.md` の skill 化 | 後続 Issue（4-1 想定） |
+
+Remember to use the GitHub CLI (`gh`) for all GitHub-related tasks.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,337 @@
+---
+description: Issue の実装検証を行います。
+argument-hint: "<issue-number>"
+disable-model-invocation: true
+---
+Issue #$ARGUMENTS の実装検証を行ってください。
+
+**`/develop` 完了後、`/6`（PR 作成）前に同一実装セッションで実行するコマンドです。**
+
+---
+
+## 概要
+
+`/verify` は、実装内容の **事実確認と証跡作成** を担当します。
+ここでは「何を実行し、何を確認し、何が未確認か」を揃えます。
+
+> **責任分離**: `/verify` は機械的な事実確認、後続の独立レビュー（後続 Issue で `/review` として整備予定）は実装者文脈を外した見落とし検出。本コマンドでは Codex 単独レビュー（Step 5）まで実施する。
+
+**フロー**:
+`/verify`（Step 1〜4: 検証）→ Step 5: Codex コード差分レビュー → Step 6: Issue コメント記録
+
+---
+
+## 手順
+
+### Step 1: 変更内容と入力を固定
+
+`/verify` は `/6`（PR 作成のコミット）より前に実行されるため、実装はコミット済みではなく
+**ワーキングツリーに残っている可能性が高い**。コミット済み差分（`MERGE_BASE...HEAD`）だけを見ると
+未コミット変更が抜け落ちて検証入力が空になる。コミット済みとワーキングツリーの両方を取得する。
+
+```bash
+# Issue 内容と既存コメント取得
+gh issue view $ARGUMENTS --comments
+
+# main 同期 + merge-base 算出（main 側の追加変更を「削除」と誤認しないため）
+git fetch origin main
+MERGE_BASE=$(git merge-base HEAD origin/main)
+
+# 1. コミット済みの差分（merge-base...HEAD）
+echo "--- Committed diff (MERGE_BASE...HEAD) ---"
+git diff "$MERGE_BASE"...HEAD --stat
+git diff "$MERGE_BASE"...HEAD --name-only
+
+# 2. ワーキングツリー差分（staged + unstaged）— 未コミットの実装を取りこぼさない
+echo "--- Working-tree diff (HEAD vs working tree) ---"
+git diff HEAD --stat
+git diff HEAD --name-only
+
+# 3. Untracked ファイル（新規作成されたが add されていないファイル）
+echo "--- Untracked files ---"
+git ls-files --others --exclude-standard
+```
+
+確認すること:
+- Issue 本文の受け入れ条件
+- `/develop` で記録した実装サマリー
+- 変更ファイルと主要レイヤー（**コミット済み + ワーキングツリー + untracked の合算**）
+- 実行コンテキスト（main / worktree、worktree path、branch、merge-base）
+
+> **未コミットで `/verify` する場合**: ワーキングツリー差分と untracked が空でないことを確認してから次ステップへ。両方が空なら「実装が見えていない」状態のため、`/develop` に戻るか、コミットしてから再実行する。
+
+### Step 2: 構成・配置チェック
+
+新規ファイル・変更ファイルが正しいディレクトリ構成と命名規則に従っているか確認する。
+ルール参照: `.claude/rules/file-naming.md`
+
+| チェック | 確認内容 |
+|---------|---------|
+| ディレクトリ構成 | Backend: `kernel/`, `modules/<domain>/{domain,infrastructure,presentation}/` の分離 |
+| ファイル配置 | 正しいレイヤーに配置されているか（例: ビジネスロジックが `presentation/` に漏れていないか） |
+| 命名規則 | Python: snake_case、TS: kebab-case（ファイル）/ PascalCase（コンポーネント）、ドキュメント: kebab-case |
+| 重複チェック | 同じロジック・定義が複数箇所に存在しないか |
+| import 整理 | 不要な import、循環参照がないか |
+
+問題があれば修正してから次のステップへ。
+
+### Step 3: 品質ゲート再実行（必須）
+
+`/develop` で実行した品質チェックが、**実際に成立しているか** を改めて実行・確認する。
+
+#### Step 3-1: 変更レイヤーごとの品質チェック
+
+```bash
+# Backend のみ
+make test-backend
+
+# Frontend のみ
+make test-frontend
+
+# 両方変更
+make test
+
+# .claude/ の dx-docs 変更時
+make validate-claude
+
+# DocDD 変更時
+make traceability
+```
+
+#### Step 3-2: TDD 証跡確認
+
+`/develop` の実装サマリーの「TDD 証跡」テーブルを確認する。
+
+| 確認項目 | PASS 条件 |
+|---------|---------|
+| TDD 判定が記載されている | `必須` または `スキップ（理由）` のいずれか。空欄 = FAIL |
+| TDD 必須の場合: RED コマンドが記録されている | 実行コマンドと FAILED 結果が明示されている |
+| TDD 必須の場合: GREEN コマンドが記録されている | 実行コマンドと PASSED 結果が明示されている |
+| TDD 必須の場合: `0 selected` / `all skipped` が RED/GREEN に使われていない | 失敗・成功が明示的に確認されている |
+| TDD スキップの場合: 理由が記載されている | 「空欄」「理由なし」は FAIL |
+
+不十分な場合は、`/develop` 側に戻って RED/GREEN を改めて実行・記録する。
+
+#### Step 3-3: 失敗扱いにする例
+
+- `pytest` が marker 条件で全 deselect
+- `npm run xxx` が script 不在で失敗
+- `make test-backend` / `make test-frontend` / `make validate-claude` / `make traceability` が FAIL
+- 実行したと書いてあるが結果が残っていない
+
+### Step 4: 挙動・契約・導線の確認
+
+変更種別に応じて、**最短導線** で挙動を確認する。
+
+#### API / Schema / 型変更
+- request / response が Issue と実装で一致している
+- 呼び出し元、状態管理、次画面の期待値が一致している
+- 正常系だけでなく、主要な異常系も確認する
+- 関連する `docs/7-axis/6_API/<domain>/*.yaml` が更新されている
+
+#### 画面 / 状態管理 / ルーティング変更
+- 入口画面から完了画面までの導線が通る
+- 戻る、再読み込み、URL パラメータ欠落時の挙動を確認する
+- 分岐条件がある場合は代表パターンを確認する
+
+#### DB / Migration 変更
+- model / migration / repository / service / API が整合している
+- 必要に応じて upgrade / downgrade、既存データ影響、NOT NULL / FK 制約を確認する
+- `docs/7-axis/3_DM/DM-*.md` が更新されている
+
+#### 軽量ブラウザヘルスチェック（フロントエンド変更がある場合）
+
+**目的**: ローカルで即時確認できる範囲のランタイム異常（JS error / 4xx / 5xx）を PR 作成前の最後の関門として検知する。
+**対象**: `apps/frontend/` 配下を変更した Issue。
+**非対象**: API / バックグラウンド処理 / 設定ファイルのみの変更 → `N/A` として記録。
+
+##### 実行手順
+
+1. **dev サーバー起動確認**:
+   ```bash
+   # 既に起動していれば不要
+   cd apps/frontend && npm run dev > /tmp/nextjs-dev.log 2>&1 &
+   ```
+
+2. **対象ページへ手動遷移**: `http://localhost:3000/対象URL` をブラウザで開く
+
+3. **ブラウザ DevTools の Console を確認**:
+   - 新たな `error` / `warn` が出ていないか確認（0 件なら PASS）
+   - 出ている場合は内容を確認し、本 Issue の変更起因なら修正
+
+4. **Network タブで 4xx / 5xx を確認**:
+   - 意図しない `4xx` / `5xx` がないか確認（0 件なら PASS）
+
+> **N/A にしていいのは**「ブラウザ導線自体が存在しない変更」だけ。フロントエンド変更があるのに「ローカル再現が難しい」という理由で N/A にしないこと。
+
+#### DocDD / TC / Traceability 確認
+
+DocDD の変更がある、または本来あるべき変更がある場合は以下を確認:
+- DM / API / UC / SR と実装内容が一致している
+- テストが追加・変更された場合、`docs/testing/traceability/<domain>_map.json` が更新されている
+- 仕様変更・新規分岐・API 契約変更があるのにテスト差分がない場合、**理由が記録されている**
+- TC 軸に残すべき内容が未反映でない
+
+> **Note**: UI 設計（Pencil）の整合性確認は `/plan` Phase 1.5 で完結する。`/verify` では比較を行わない（`.claude/rules/project-workflow.md` 参照）。
+
+### Step 4.5: エージェントチーム検証（コンテキストフレッシュ）
+
+**2 レイヤー以上にまたがる変更では、コンテキストフレッシュ（context fresh）spawn による検証が必須。**
+単一レイヤーの変更では単一セッションで検証してよい。
+
+**コンテキストフレッシュの原則**:
+- 実装セッションのコンテキストを引き継いだまま検証しないこと
+- 新しいサブエージェントを spawn し、最小限の入力（Issue 本文、`git diff`、テスト結果）のみ渡すこと
+- 修正後の再検証でも新しいサブエージェントを spawn すること
+
+参照: `.claude/rules/agent-teams.md`
+
+**バックエンド検証チーム例:**
+```text
+Issue #$ARGUMENTS の実装をチームで検証して。
+- スキーマ担当: Model 定義、マイグレーション、既存モデルとの整合性
+- サービス担当: ロジック、DI、トランザクション、エラーハンドリング
+- API 担当: エンドポイント設計、テストカバレッジ、認証認可
+- 横断チェッカー: 各担当の報告を突き合わせ、レイヤー間の隙間を指摘
+- テスト実行担当: 実行結果と no-op テストがないか確認
+```
+
+**フロントエンド検証チーム例:**
+```text
+Issue #$ARGUMENTS のフロントエンド実装をチームで検証して。
+- コンポーネント担当: Container/Presentational 分離、Private Folder 構成
+- データフェッチ担当: Server/Client 境界、ローディング/エラー/状態復元
+- UI/UX 担当: レスポンシブ、アクセシビリティ、デザインとの差分
+- 横断チェッカー: API 契約、型、状態管理、画面遷移の整合性
+```
+
+指摘の扱い:
+- 🔴 必須修正は `/6`（PR 作成）に渡す前に解消
+- 🟡 推奨は理由付きで記録
+- スコープ外に見えても本 Issue 実装に直接関連する問題は本 Issue 内で対応
+
+### Step 5: Codex コード差分レビュー
+
+実装の独立レビューとして Codex CLI でコード差分をレビューする。
+ルール参照: `.claude/rules/codex-review.md`
+
+> ⚠️ **`/plan` と `/verify` では Codex への渡し方が異なる**
+> - `/plan`: 計画テキストのレビュー → `--base main` は使わない
+> - `/verify`: **コード差分のレビュー** → `--base main` を使う
+> - `--base` と `[PROMPT]` の同時使用は不可（v0.120+ で確認済み）
+
+#### Codex 利用可否を判定
+
+```bash
+codex --version > /dev/null 2>&1
+```
+
+#### Codex が利用可能な場合
+
+```bash
+codex review --base main
+```
+
+> **注意**: Codex の応答には 3〜5 分かかる場合がある。30 秒で応答なしと判定しないこと。
+> **worktree の場合**: サマリに worktree パス（例: `.claude/worktrees/issue-<N>/`）を明記すること。
+
+#### Codex が利用不可の場合（Fallback）
+
+**サイレントスキップ禁止** — 必ずユーザーに通知する。
+
+1. `.claude/templates/codex-review-handoff.md` の「コードレビュー」セクションを出力
+2. ユーザーに手動で Codex / ChatGPT にレビューを依頼するよう案内
+
+#### Codex 結果の反映
+
+1. **指摘を分類**（`.claude/rules/codex-review.md` 参照）:
+   - 🔴 必須修正: 本 Issue 内で即対応（バグ・脆弱性・データ損失リスク）
+   - 🟡 推奨: 理由付きで記録、対応要否を判断
+   - 🟢 参考: 記録のみ
+   - ❌ 却下: 理由を付けて却下
+
+2. **必要な修正を本セッション内で即適用**: 🔴 / 🟡 で actionable な修正案は、ユーザー承認を待たずにその場で修正し、Step 3 の品質チェックを再実行する。
+
+> **逃げない**: 🔴 / 🟡 で actionable な指摘を後回しにしない。`/verify` は実装検証の最後の関門。
+
+3. **差分があれば Issue 本文を更新**: `gh issue edit $ARGUMENTS --body-file ...` または `/update-issue` を実行
+
+> **後続 Issue で Codex + Claude SA × 2 の 3 reviewer 並列レビュー（multi-model-review）を導入予定**。本コマンドでは Codex 単独レビューに留める。
+
+### Step 6: Issue コメントに記録
+
+検証結果全体（Step 1〜4 の結果 + Step 5 の Codex レビュー結果）をまとめて記録する。
+
+- 構成は `.claude/templates/verification-result-comment.md` に従う（**見出し・TDD 判定行・Coverage 結果行の記法を厳守**）
+  - 見出し: `## 実装検証結果（/verify）` をそのまま使う（`/develop 完了時点` suffix を付けない）
+  - TDD 判定行: スキップ時は `スキップ（理由: ...）` と同一セル内に書く
+  - Coverage 結果行: `PASS` / `N/A` / `未解消` のみ（装飾なし）
+- `ブラウザ確認` を必ず埋める（フロントエンド変更がある Issue は実施、なければ `N/A`）
+- `未解消` が残る場合は理由と対応方針を明記する
+
+```bash
+gh issue comment $ARGUMENTS --body-file /tmp/verify_result_$ARGUMENTS.md
+```
+
+---
+
+## チェックリスト
+
+`/6`（PR 作成）に渡す前に確認:
+
+- [ ] 変更レイヤーに対応する `make test-backend` / `make test-frontend` / `make test` のいずれかを再実行した
+- [ ] `.claude/` の dx-docs を変更した場合は `make validate-claude` を再実行した
+- [ ] DocDD を更新した場合は `make traceability` を再実行した
+- [ ] 実行した品質チェックと結果が残っている
+- [ ] `0 selected` / `all skipped` / `script not found` を成功扱いにしていない
+- [ ] **TDD 証跡が `verification-result-comment.md` に転記されている**（必須 / スキップ（理由）のいずれか）
+- [ ] **TDD 必須の場合: RED / GREEN コマンドの両方が確認・転記されている**
+- [ ] 主要導線・契約・状態遷移を確認した
+- [ ] DocDD / TC / traceability map の更新要否を確認した
+- [ ] フロントエンド変更がある場合は軽量ブラウザヘルスチェック（Console / Network）を実施した
+- [ ] Codex コード差分レビュー（`codex review --base main`）を実施した
+- [ ] 検証結果を Issue コメントに記録した
+
+---
+
+## 次のステップ
+
+Step 6 完了後、ユーザーに以下を案内する:
+
+```
+Issue #<N> 検証完了:
+  - 品質ゲート: PASS
+  - DocDD / 証跡: PASS / N/A
+  - Codex レビュー指摘: 🔴 X 件 / 🟡 Y 件 / 🟢 Z 件 / ❌ W 件（修正適用済 / 未解消）
+  - ブラウザヘルスチェック: PASS / N/A
+
+次のステップ:
+  /6              # PR 作成
+```
+
+> **新しいセッションで PR 作成 / 独立レビューを行うのが推奨**: 検証者の文脈を引き継いだまま PR を出すと、見落としを PR コメントとして拾えない。
+
+---
+
+## 注意事項
+
+- `/develop` 完了後、PR 作成前に必ず実行すること
+- 品質チェックは変更箇所に応じて再実行する（全レイヤー網羅でなくて OK）
+- フロントエンド変更がある場合は軽量ブラウザヘルスチェックを必ず実施する
+- Codex レビューはサイレントスキップ禁止。Codex 未導入時は handoff テンプレートで案内する
+
+---
+
+## 📋 後続 Issue で導入予定（forward reference の隔離）
+
+| 参照先（未存在） | 用途 | 予定 Issue |
+|--------------|------|----------|
+| `/review` コマンド | 独立レビュー（実装者文脈を外した見落とし検出） | 後続 Issue（2-2 想定） |
+| `.claude/rules/multi-model-review.md` | Codex + Claude SA × 2 の 3 reviewer 並列レビュー | 後続 Issue（D-1 想定） |
+| `.claude/skills/verify-input-capture/SKILL.md` | Step 1 の入力固定 SSOT | 後続 Issue（5-1 想定） |
+| `.claude/skills/receiving-code-review/SKILL.md` | レビュー指摘の分類スキル | 後続 Issue（4-3 想定） |
+| `scripts/claude/verify-issue.sh` / `quality-gate.sh` | Issue 単位の品質ゲート自動化 | 後続 Issue（5-1 想定） |
+| `make quality-gate` ターゲット | 品質ゲート一括実行 | 後続 Issue（5-1 想定） |
+| `/screen-verify` + TC YAML 自動実行 | post-merge ステージング検証 | 後続 Issue（D-X 想定） |
+
+Remember to use the GitHub CLI (`gh`) for all GitHub-related tasks.

--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -1,0 +1,308 @@
+---
+description: Issue 用の worktree 環境を作成します。
+argument-hint: "<issue-number>"
+disable-model-invocation: true
+---
+Create the canonical worktree environment for Issue $ARGUMENTS.
+
+`/worktree` は checkout 準備コマンドです。Issue 情報取得 → worktree 作成 → ブランチリネーム → 環境セットアップを一括で行います。
+
+**前提知識**: [.claude/skills/parallel-development/SKILL.md](../skills/parallel-development/SKILL.md) — 判定 SSOT（原則 worktree 推奨）・Track A/B（.env 要否）・複数エディタ並走パターン・worktree 互換性サマリ・マージ順序
+
+> **不変条件**: 本 Issue で worktree を使うか否かの判定は SKILL.md の「判定 SSOT」に従う。原則 worktree 推奨、例外は単独 sequential 作業をユーザーが明示した場合のみ。
+
+> **CLI-first 原則**: 本コマンドは `git worktree add` CLI を使う（`.claude/rules/cli-first.md` 準拠）。MCP の `EnterWorktree` ビルトインツールは使わない。
+
+---
+
+## 目的
+
+- Issue 情報を取得する
+- main ベースで worktree を作る
+- 命名規則に沿ったブランチへリネームする
+- 別ウィンドウ / 別セッションで安全に作業できる状態を作る
+
+## 標準フロー
+
+```bash
+/worktree <N>
+/plan <N>
+/develop <N>
+/verify <N>
+/6                 # PR 作成（旧コマンド体系。後続 Issue で /pr 化予定）
+```
+
+## 関連コマンド
+
+| コマンド | 用途 |
+|---------|------|
+| `/c <N>` | 未マージ worktree の破棄（旧コマンド体系。`/7` がマージ前提のため） |
+
+> 後続 Issue で `/discard-worktree` `/merge` への置換を予定。
+
+---
+
+## 手順
+
+### Step 1: Issue 情報を取得
+
+```bash
+gh issue view $ARGUMENTS --json title,number,state
+```
+
+- Issue が存在しない場合はエラー
+- Issue が Close 済みの場合は警告
+
+### Step 2: dirty check
+
+未コミット変更がある状態で `git checkout main` すると衝突する。先にコミットまたはスタッシュする。
+
+```bash
+git status --porcelain
+```
+
+**変更がある場合**: ユーザーに確認し、`/commit-and-push` またはスタッシュしてから進む。
+
+> **別ターミナルで Track A が作業中の場合**: `git checkout main` は共有チェックアウトを切り替えてしまう。Track A の作業を一時中断（コミット or スタッシュ）してから実行するか、Track A 完了後に実行する。
+
+### Step 3: main ブランチに切り替え
+
+```bash
+# 現在のブランチを確認
+git branch --show-current
+
+# main でない場合は切り替え
+git checkout main
+git pull origin main
+```
+
+### Step 4: git worktree add でワークツリーを作成
+
+CLI-first 原則に従い `git worktree add` を直接呼ぶ:
+
+```bash
+# Issue タイトルから type と short-description を決定（branch-naming.md 準拠）
+# 例: feature/issue-42-add-login-page
+
+WORKTREE_PATH=".claude/worktrees/issue-$ARGUMENTS"
+BRANCH_NAME="<type>/issue-$ARGUMENTS-<short-description>"
+
+# main ベースで worktree + ブランチを同時作成
+git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" main
+```
+
+- `.claude/worktrees/issue-<number>/` にワークツリーが作成される（`.gitignore` 登録済み）
+- `<type>/issue-<number>-<short-description>` ブランチが main ベースで作成される
+- 既に同名 worktree / ブランチがある場合は `git worktree add` がエラー終了する。Step 1 で警告が出ていなければそのまま中断し、ユーザーに確認する
+
+> **branch-naming**: `<type>` は `feature` / `fix` / `refactor` / `docs` / `test` / `chore` のいずれか（`.claude/rules/branch-naming.md`）。
+
+### Step 5: worktree に移動
+
+```bash
+cd "$WORKTREE_PATH"
+
+# 確認
+git branch --show-current
+pwd
+```
+
+### Step 6: 環境変数ファイルのセットアップ（allowlist + 安全策）
+
+worktree は `.gitignore` 対象のファイル（`.env`, `.env.local` 等）を共有しないため、メインリポジトリからシンボリックリンクを作成する。
+
+> **Track 判定**: Issue が `.claude/` / `docs/` / `.github/` / `scripts/` など `apps/` 以外のみを触る Track B の場合、Backend/Frontend の `.env` は **不要**。判定基準は `.claude/skills/parallel-development/SKILL.md` の Track 分類節（SSOT）を参照。
+
+#### 安全策（必須）
+
+env symlink は secret 漏洩・自己参照による .env 破壊のリスクが高いため、以下を厳守する:
+
+1. **cwd ガード**: スクリプト先頭で `git rev-parse --show-toplevel` を取得し、main repo と同一なら停止する（Step 5 が抜けたまま Step 6 を実行すると、main の `.env` を自己参照 symlink で破壊する事故を防ぐ）
+2. **allowlist 限定**: 対象は `apps/backend/.env` と `apps/frontend/.env.local` の **2 ファイルのみ**。広範な `.env.*` を symlink しない
+3. **存在確認**: main repo にファイルが存在する場合のみ symlink を作成
+4. **ユーザー確認**: 初回作成時は「main repo の `.env` を symlink で参照しますか？」と 1 回確認してから進む
+5. **`.env.example` 優先**: main repo にもファイルがなければ `cp .env.example .env` の手順を案内（symlink ではなくコピー）
+6. **既存ファイル退避**: 既に通常ファイルの `.env` があれば `.env.bak` に退避してから symlink
+7. **絶対パスで操作**: symlink の作成先・参照先はいずれも `$WORKTREE_ROOT/...` / `$MAIN_ROOT/...` の絶対パス（同一性比較で自己参照を二重防止）
+
+```bash
+# メインリポジトリのルートパスを取得（primary worktree）
+MAIN_ROOT=$(git worktree list --porcelain | head -1 | sed 's/worktree //')
+
+# 現在地を worktree ルートに固定する（Step 5 が反映されていない別シェルでも安全に動作させる）
+WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
+cd "$WORKTREE_ROOT"
+
+# 安全策: cwd が main repo（primary worktree）と同一なら symlink で .env を破壊するリスクがあるため停止
+if [ "$WORKTREE_ROOT" = "$MAIN_ROOT" ]; then
+  echo "❌ Step 6 は worktree 内でのみ実行可能（現在は main checkout: $WORKTREE_ROOT）"
+  echo "   先に Step 4-5 を実行して worktree に入ってからやり直してください"
+  return 1 2>/dev/null || exit 1
+fi
+
+# Track 判定（Step 1 で取得した Issue 内容から判断）
+# - Track A: apps/ を含む変更 → Backend/Frontend .env 必要
+# - Track B: .claude/ / docs/ / .github/ / scripts/ 等（apps/ 非変更）→ .env 不要
+# Claude が判定し、Track B なら TRACK="B"、Track A または不明なら TRACK="A"
+TRACK="A"  # デフォルトは A（env セットアップを行う）。Track B 確定時のみ B に変更
+
+# allowlist: この 2 ファイルのみを対象とする
+ENV_ALLOWLIST=("apps/backend/.env" "apps/frontend/.env.local")
+
+setup_env() {
+  local label="$1"    # "Backend" or "Frontend"
+  local path="$2"     # allowlist 内のパス（worktree からの相対）
+  local main_path="$MAIN_ROOT/$path"
+  local worktree_path="$WORKTREE_ROOT/$path"
+
+  # 自己参照 symlink 防止（万一 cwd ガードを抜けても、絶対パス比較で再ガード）
+  if [ "$worktree_path" = "$main_path" ]; then
+    echo "  ❌ $label $path → main と worktree が同一パス。symlink を作成しない"
+    return 1
+  fi
+
+  # 既存の通常ファイルは退避
+  if [ -e "$worktree_path" ] && [ ! -L "$worktree_path" ]; then
+    echo "  ℹ️  $label $path は通常ファイル → $path.bak に退避"
+    cp "$worktree_path" "$worktree_path.bak"
+  fi
+
+  if [ -f "$main_path" ]; then
+    # ユーザー確認は呼び出し側で実施済みの前提（Track A 初回のみ）
+    if /bin/ln -sf "$main_path" "$worktree_path"; then
+      echo "  ✅ $label $path → symlink 作成"
+      return 0
+    else
+      echo "  ❌ $label $path → symlink 作成失敗（ln exit code: $?）"
+      echo "      手動で作成してください: /bin/ln -sf \"$main_path\" \"$worktree_path\""
+      return 1
+    fi
+  fi
+
+  # main にも存在しない場合は .env.example 優先のフォールバック
+  if [ "$TRACK" = "B" ]; then
+    echo "  ⏭️  $label $path → スキップ（Track B は apps/ 非変更のため .env 不要）"
+  else
+    echo "  ℹ️  $label $path → main にも未存在。以下でセットアップ:"
+    echo "      cp ${path%.env*}.env.example $path  # .env.example が存在する場合"
+  fi
+  return 0
+}
+
+echo "環境変数ファイルのセットアップ（Track: $TRACK / allowlist: ${#ENV_ALLOWLIST[@]} ファイル / worktree: $WORKTREE_ROOT）"
+setup_env "Backend"  "${ENV_ALLOWLIST[0]}"
+setup_env "Frontend" "${ENV_ALLOWLIST[1]}"
+```
+
+> **なぜ symlink?**: `.env` を直接コピーすると、メインで値を変更しても worktree に反映されない。symlink なら常にメインの最新値を参照できる。
+> **broken symlink 防止**: `[ -f ]` で実体の存在を確認してから `ln -sf` する。
+> **PATH 破損耐性**: `ln` は `/bin/ln` 絶対パスで呼ぶ。
+
+### Step 7: 依存パッケージのインストール
+
+worktree は `.gitignore` 対象のファイル（`node_modules/` 等）を共有しないため、必要な依存をインストールする。
+
+> ⚠️ **重要**: リポジトリ root には `package.json` が存在しない。`package.json` は `apps/frontend/` 配下にある。
+
+```bash
+# Frontend の依存インストール
+# 推奨: Makefile 経由
+make install-dev
+
+# または直接 npm を呼ぶ場合は --prefix を必ず指定（root の package.json 不在エラー回避）
+npm --prefix apps/frontend install
+```
+
+> **Backend (Python)**: venv はホスト共有 or Docker 内実行のため、通常は追加作業不要。
+> **`make install-dev` の挙動**: Frontend の `npm install` を含む dev 依存セットアップを一括で実施する。
+
+### Step 8: 別エディタウィンドウで開く（任意）
+
+VS Code / Cursor を使っている場合は worktree ルートの **絶対パス** を渡して新しいウィンドウで開く。
+
+```bash
+# pwd ではなく worktree の絶対パスを明示的に指定
+# VS Code の場合
+code "$(git rev-parse --show-toplevel)"
+
+# Cursor の場合
+cursor "$(git rev-parse --show-toplevel)"
+```
+
+> **なぜ絶対パス?**: `npm install` 等のサブコマンドで cwd が変わる場合がある。`git rev-parse --show-toplevel` は常に worktree ルートを返すため安全。
+> **メイン Window はそのまま維持**: メインリポジトリの Window はマージ・Issue 作成等の管理操作に専有する。
+
+### Step 9: 次のステップを案内
+
+```
+Worktree 作成完了:
+  パス: .claude/worktrees/issue-<N>
+  ブランチ: <type>/issue-<N>-<short-description>
+
+次のステップ（worktree 内で実行）:
+  /plan <N>      # 計画立案（未計画の場合）
+  /develop <N>   # 実装開始
+  /verify <N>    # 実装検証
+  /6             # PR 作成
+```
+
+---
+
+## 利用パターン
+
+### 方法 A: 同一セッション内（短い作業向け）
+
+```bash
+/worktree 42     # worktree 作成 + ブランチセットアップ
+/plan 42         # 計画立案
+/develop 42      # 実装
+/verify 42       # 実装検証（同一セッション）
+# ⚠️ 検証は新しいセッションを開いて行うのが推奨（確証バイアス回避）
+/6               # PR 作成（worktree 内で最後のステップ）
+# → メインリポジトリのターミナルに切り替え
+/7 42            # メインから: マージ + クリーンアップ
+```
+
+### 方法 B: 別エディタウィンドウ（長時間並列向け、推奨）
+
+```bash
+# メイン Window: 別 Issue の作業を継続
+/develop 100
+
+# メイン Window のターミナルで worktree 作成
+/worktree 42     # git worktree add + 別ウィンドウ起動
+
+# 別エディタウィンドウ（.claude/worktrees/issue-42）
+/plan 42         # 計画立案
+/develop 42      # 実装
+/verify 42       # 実装検証
+/6               # PR 作成
+
+# メイン Window に戻る
+/7 42            # マージ + クリーンアップ
+```
+
+> **別ウィンドウの利点**: 検索対象・タブ・AI 文脈・ターミナル cwd・Git ブランチ表示が全て worktree に揃い、メイン checkout を誤って触るリスクがなくなる。
+
+---
+
+## 注意事項
+
+- `.claude/worktrees/` は `.gitignore` 登録済み
+- worktree 内でも `.claude/commands/`, `.claude/skills/`, `.claude/rules/` は利用可能（git 管理下のため）
+- 既に同名の worktree が存在する場合は `git worktree add` がエラー終了する
+- マージ操作（`gh pr merge` / `git worktree remove`）はメインリポジトリから実行する
+
+---
+
+## 📋 後続 Issue で導入予定（forward reference の隔離）
+
+| 参照先（未存在） | 用途 | 予定 Issue |
+|--------------|------|----------|
+| `/discard-worktree` コマンド | 未マージ worktree の破棄（canonical） | 後続 Issue（2-2 想定） |
+| `/merge` コマンド | PR マージ + worktree 削除（canonical） | 後続 Issue（2-2 想定） |
+| `validate-merge-cwd.sh` hook | worktree 内からのマージ操作を決定論的にブロック | 後続 Issue（D-1 想定） |
+
+ARGUMENTS: issue_number
+
+Example usage: `/worktree 42`

--- a/.claude/skills/parallel-development/SKILL.md
+++ b/.claude/skills/parallel-development/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: parallel-development
+description: |
+  並列開発（Worktree）運用ルール。原則 worktree 推奨の判定 SSOT、Track A/B の分類（.env 要否）、
+  複数エディタ並走パターン、ファイル競合回避、マージ順序、worktree 互換性サマリを提供。
+  /worktree, /plan で参照される。
+---
+
+# 並列開発スキル
+
+## 概要
+
+`git worktree` コマンドを使った並列開発の運用ルールを定義する。
+
+**非ゴール**: worktree の技術的仕組みそのものの説明（Git 公式ドキュメントを参照）。
+
+## 使い方
+
+以下のコマンドで参照される:
+- `/worktree` — Worktree 作成 + ブランチセットアップ
+- `/plan` — 計画立案時に worktree 要否を案内する SSOT として参照
+
+> 後続 Issue でマージ・破棄系コマンド（`/merge` / `/discard-worktree`）を整備予定。本 Issue では `/7`（旧マージコマンド）と `/c`（旧 worktree 削除）が並存している。
+
+---
+
+## 判定 SSOT — 原則 worktree 推奨
+
+> 本節は worktree 要否判定の **単一の真実の源（SSOT）**。
+> `.claude/rules/issue-workflow.md` / `.claude/commands/{plan,worktree}.md` は本節を参照し、独自定義を書かない。
+
+### 原則
+
+**全 Issue で worktree を推奨する。** 複数エディタ・複数セッションでの並走前提では、Track を問わず worktree による checkout 隔離が必要。
+
+- 他エディタの checkout 切替で state が壊れる問題を回避
+- 同時マージのコンフリクト回避
+- PR 時の後出しブランチ切り替え手順が不要
+
+### 例外（main 直接作業が許容される条件）
+
+**単独 sequential 作業**のみ許容する。以下を **すべて満たす** 場合に限る:
+
+- 同時に他エディタセッションで作業していない（ユーザー自己申告ベース）
+- 直列に 1 Issue ずつ処理する運用である
+
+> エディタ枚数は Claude 側で決定論的に判定できない。ルールとしてはデフォルト worktree に倒し、例外適用はユーザーが明示的に宣言した場合に限る。
+
+### 例外トリガー（ユーザー自己申告の substring 一致）
+
+Claude 側は以下のいずれかの **substring** が直前のユーザー発話に含まれる場合のみ例外を適用する（full phrase 完全一致は要求しない。自然発話の variant を拾うため）:
+
+- 日本語 substring: `worktree なし` / `worktree 不要` / `worktree いらな` / `単独 sequential` / `sequential モード` / `直接 main`
+- 英語 substring: `sequential mode` / `solo sequential` / `no-worktree` / `no worktree` / `without worktree`
+
+**判定ロジック**:
+- 上記 substring の **いずれかを含む** → 例外適用
+- 含まないが「近い表現」（例: `worktree やめる` / `worktree なくていい`）→ Claude は「`worktree なし` の意味でしょうか？」と 1 回確認してからユーザー回答に従う
+- substring も近い表現も含まない → デフォルト（worktree 推奨）に倒す
+- 過去メッセージや Issue 本文からの暗黙的推測は禁止（SSOT の同一性を保つため、判定は **直前のユーザー発話のみ** を見る）
+
+**例外適用時の案内**:
+substring 一致で例外を適用した場合も、Claude は「worktree を推奨しますが単独 sequential として main 直接作業で進めます」と 1 行案内してから進める。
+
+### 判定フロー（Claude 側）
+
+```
+Issue が渡された
+  └→ 直前メッセージに上記の定型句のいずれかが含まれるか？
+       └→ Yes → main 直接作業を許容（推奨理由を 1 行案内してから進める）
+       └→ No  → worktree 必須として `/worktree <N>` を案内する（デフォルト）
+```
+
+---
+
+## 複数エディタ並走パターン
+
+実運用では複数のエディタウィンドウ（VS Code / Cursor 等）を開き、並列に Issue を進める前提で設計する。
+
+```
+┌──────────────────────┬──────────────────────┐
+│ Window 1: main       │ Window 2: worktree-A │
+│ /7 / /1 等の管理系   │ Issue #X の実装      │
+├──────────────────────┼──────────────────────┤
+│ Window 3: worktree-B │ Window 4: worktree-C │
+│ Issue #Y の実装      │ Issue #Z の実装      │
+└──────────────────────┴──────────────────────┘
+```
+
+- **Window 1 (main)**: マージ・Issue 作成・ロードマップ更新など worktree 外コマンド
+- **Window 2-N (worktree)**: それぞれ独立した Issue の `/plan` → `/develop` → `/verify` → `/6`
+
+### 運用ルール
+
+1. **main checkout は Window 1 が専有する**（他 Window が `git checkout main` すると Window 1 が壊れる）
+2. 各 worktree は独自ブランチに checkout されているため checkout 干渉はない
+3. Track A 同士でもモジュールが異なれば並列可（同モジュールは直列にする）
+
+---
+
+## Track 分類（`.env` 要否のみに限定）
+
+Track A/B は **`.env` セットアップの要否判定のみ** に使う。worktree 要否とは独立。
+
+| Track | 条件 | `.env` セットアップ |
+|-------|------|:-------------------:|
+| Track A | `apps/backend/` / `apps/frontend/` を変更する | 必要（`/worktree` Step 6 で symlink 作成）|
+| Track B | `.claude/` / `docs/` / `.github/` / `scripts/` 等 | 不要（apps/ 非変更のため） |
+
+> **判断に迷う場合**: `apps/` 配下を 1 行でも変更するなら Track A。
+> **worktree 要否**: Track に関わらず原則 worktree 推奨（本節「判定 SSOT」参照）。
+
+---
+
+## ワークツリー構成
+
+```
+docdd-starters/                    # メインリポジトリ（Window 1 専有）
+└── .claude/
+    └── worktrees/                 # .gitignore 登録済み
+        ├── issue-42/              # Window 2 用
+        ├── issue-99/              # Window 3 用
+        └── issue-123/             # Window 4 用
+```
+
+> `git worktree add .claude/worktrees/issue-<N> -b <branch>` で作成する（CLI-first 原則）。
+
+---
+
+## コマンドフロー
+
+```
+[メインリポジトリ (Window 1)]
+/worktree <N>  → worktree 作成 + ブランチセットアップ + 別ウィンドウ起動の案内
+
+[Worktree 内 (Window 2-N)]
+/plan <N>       → 計画立案（未計画の場合）
+/develop <N>    → 実装（旧 /4）
+/verify <N>     → 実装検証（旧 /5）
+/6              → PR 作成 ← worktree 内の最後のステップ
+
+[メインリポジトリに戻る (Window 1)]
+/7 <N>          → PR マージ + クリーンアップ（旧コマンド体系。後続 Issue で /merge に置換予定）
+/c <N>          → 未マージ Worktree 削除（旧コマンド体系）
+```
+
+> **重要**: マージ操作（`gh pr merge` / `git worktree remove`）はメインリポジトリから実行する。
+> worktree 内から自身を削除すると cwd が消えて後続ステップが失敗する。
+
+---
+
+## ファイル競合回避の原則
+
+1. **同じモジュールに触れる Issue は直列にする**
+2. **別モジュールの Track A 同士は並列可**（worktree で checkout 隔離されているため）
+3. **Track B 同士も自由に並列可**
+4. **Track A + Track B の並列は推奨**
+
+## マージ順序の注意
+
+1. **Track B を先にマージ** → Track A が最新の main を取り込める
+2. Track A と B が独立なら順序は自由
+3. **同モジュールの Track A 同士は必ず直列**
+
+---
+
+## Worktree 互換性サマリ
+
+### ✅ 問題なし
+
+| コマンド / 操作 | 理由 |
+|----------------|------|
+| `/plan` | コード読み取り + `gh` CLI のみ |
+| `/develop` + `make test-backend` | DB はホスト共有 or Docker。PYTHONPATH は Makefile が設定 |
+| `/verify` | コード読み取り + `gh` CLI + `make` のみ |
+| `/6`（PR 作成） | `gh` CLI のみ |
+| `git diff` / `git merge-base` | worktree でも正常動作 |
+| `make validate-claude` | スクリプト経由のため worktree でも動作 |
+| `make traceability` | スクリプト経由のため worktree でも動作 |
+| pytest discovery | `pytest.ini` の `testpaths` は相対パス |
+
+### ⚠️ 要注意
+
+| 項目 | 問題 | 対策 |
+|------|------|------|
+| Backend `.env` | worktree に存在しない | Track A の `/worktree` Step 6 で symlink を作成（main 側に存在する場合のみ） |
+| Frontend `.env.local` | worktree に存在しない | Track A の `/worktree` Step 6 で symlink を作成（main 側に存在する場合のみ） |
+| `node_modules/` | worktree に存在しない | Track A の `/worktree` Step 7 で `npm --prefix apps/frontend install` |
+
+### ❌ worktree で実行しない（運用ルール）
+
+| 操作 | 理由 |
+|------|------|
+| マージ操作（`gh pr merge` / `git worktree remove`） | worktree 内から自身を削除すると cwd が消える / main 同期が silent にスキップされる |
+| `make deploy-*` | デプロイはメインから |
+| Terraform `apply` | 状態管理はメインから |
+| Docker / Compose 操作 | 固定パス前提 |
+
+> 上記はルールベース（hook 自動ブロックは未実装）。後続 Issue で `validate-merge-cwd.sh` 相当の hook 追加を検討する。
+
+---
+
+## 関連ファイル
+
+- [.claude/commands/worktree.md](../../commands/worktree.md) — Worktree 作成（canonical）
+- [.claude/commands/a.create-worktree.md](../../commands/a.create-worktree.md) — Worktree 作成（旧コマンド・並存）
+- [.claude/commands/b.move-to-worktree.md](../../commands/b.move-to-worktree.md) — Worktree 移動（旧コマンド・並存）
+- [.claude/commands/c.remove-worktree.md](../../commands/c.remove-worktree.md) — Worktree 削除（旧コマンド・並存）
+- [.claude/rules/branch-naming.md](../../rules/branch-naming.md) — ブランチ命名規則
+- [.claude/rules/cli-first.md](../../rules/cli-first.md) — CLI-first 原則
+- [.claude/rules/agent-teams.md](../../rules/agent-teams.md) — エージェントチーム運用
+
+---
+
+## 📋 後続 Issue で導入予定（forward reference の隔離）
+
+| 参照先（未存在） | 用途 | 予定 Issue |
+|--------------|------|----------|
+| `/merge`, `/discard-worktree` コマンド | canonical マージ・破棄フロー | 後続 Issue（2-2 想定） |
+| `validate-merge-cwd.sh` hook | worktree 内からのマージ操作を決定論的にブロック | 後続 Issue（D-1 想定） |

--- a/.claude/templates/implementation-summary-comment.md
+++ b/.claude/templates/implementation-summary-comment.md
@@ -1,0 +1,87 @@
+# 実装サマリーコメントテンプレート
+
+`/develop` 完了時点で Issue コメントに残すテンプレート。`/verify` の証跡確認の基準資料となる。
+
+> **記法ルール**: 後続で evidence-checker（自動証跡検証）を導入する際の互換性を保つため、以下の記法を厳守する:
+> - **見出し**: `## 実装サマリー（/develop 完了時点）` をそのまま使う（`/verify` のサマリーと混同しない）
+> - **TDD 判定行**: スキップ時は `スキップ（理由: ...）` と **同一セル内** に理由を書く
+> - **結果値**: `PASS` / `N/A` / `未解消` のみ（`✅ PASS` / `PASS（31/31）` / `PASS — 詳細` 等の装飾は付けない）
+> - **ブラウザ確認**: `PASS` / `Deferred to /verify` / `N/A` / `未解消` のみ
+
+```markdown
+## 実装サマリー（/develop 完了時点）
+
+### Status
+- [完了 / 継続 / ブロッカーあり] — 1 行で記載
+- 次アクション: `/verify <N>` / ユーザー判断待ち（理由）など
+
+### 計画からの差分
+- **追加 X / 変更 Y / 削除 Z**
+- 主要な変更点 3 行以内:
+  - [最も重要な変更 1]
+  - [最も重要な変更 2]
+  - [最も重要な変更 3]
+- **変更理由**: [なぜ計画と変えたか — 計画通りなら「計画通り」]
+
+### 実装したファイル
+[主要なファイルのみリストアップ。詳細は `git diff` で確認]
+- `path/to/file1.py`: [何をしたか 1 行]
+- `path/to/file2.tsx`: [何をしたか 1 行]
+
+### 品質チェック結果
+| 種別 | コマンド | 結果 |
+|------|---------|------|
+| バックエンド | `make test-backend` | PASS / FAIL（理由）/ N/A |
+| フロントエンド | `make test-frontend` | PASS / FAIL（理由）/ N/A |
+| 全体 | `make test` | PASS / FAIL（理由）/ N/A |
+| frontmatter | `make validate-claude` | PASS / FAIL（理由）/ N/A |
+| traceability | `make traceability` | PASS / FAIL（理由）/ N/A |
+
+> 変更レイヤーに該当するもののみ実行。N/A は「変更なし」を意味する。
+
+### TDD 証跡
+| 項目 | 内容 |
+|------|------|
+| TDD 判定 | 必須 / スキップ（理由: ）|
+| 追加したテスト | Backend: `apps/backend/tests/.../test_xxx.py::test_name` / Frontend: `apps/frontend/src/.../__tests__/xxx.test.ts`（スキップの場合は「なし」）|
+| RED コマンド | `make test-backend` / `make test-frontend` 等（スキップの場合は「なし」）|
+| RED 結果 | FAILED: X failed（AssertionError / ImportError 等）/ なし（スキップ）|
+| GREEN コマンド | `make test-backend` / `make test-frontend` 等（スキップの場合は「なし」）|
+| GREEN 結果 | PASSED: X passed / なし（スキップ）|
+
+### Coverage 証跡
+| 項目 | 内容 |
+|------|------|
+| Critical Path 判定 | /plan の検証定義から転記（Critical / Non-critical / Mixed / N/A） |
+| 保護レイヤー | /plan の検証定義から転記 |
+| Coverage expectation | /plan の検証定義から転記 |
+| Focused test commands | /plan の検証定義から転記 |
+| 結果 | PASS / N/A / 未解消 |
+
+### ブラウザ確認
+| 項目 | 結果 | 備考 |
+|------|------|------|
+| 主要導線の手動確認 | PASS / Deferred to /verify / N/A / 未解消 | [動作確認の概要] |
+| Console error | PASS / Deferred to /verify / N/A / 未解消 | [新たな error / warn の有無] |
+| Network 4xx/5xx | PASS / Deferred to /verify / N/A / 未解消 | [意図しないエラーの有無] |
+
+> **N/A**: API / バックグラウンド処理 / 設定ファイルのみの変更でブラウザ導線が存在しない場合のみ。
+> **Deferred**: `/verify` で軽量ヘルスチェックを行う場合。フロントエンド変更がある Issue では原則 `/verify` で実施。
+
+### 未解消 / 先送り
+[未実装・未確認・先送りした項目があれば明記。なければ「なし」]
+
+### `/verify` で確認してほしいポイント
+- [事実確認の重点項目 1]
+- [事実確認の重点項目 2]
+```
+
+---
+
+## 📋 後続 Issue で導入予定（forward reference の隔離）
+
+| 参照先（未存在） | 用途 | 予定 Issue |
+|--------------|------|----------|
+| evidence-checker（`scripts/claude/verify_issue_evidence.py` 相当） | コメント記法の自動検証 | 後続 Issue（5-1 / D-1 想定） |
+| ephemeral session memory writer（`scripts/claude/session_memory_writer.sh` 相当） | raw 詳細ログの memory 退避 | 後続 Issue（D-X 想定）|
+| `/screen-verify` コマンド + TC YAML 自動実行 | post-merge ブラウザ検証 | 後続 Issue（D-X 想定） |

--- a/.claude/templates/issue-implementation-plan.md
+++ b/.claude/templates/issue-implementation-plan.md
@@ -1,0 +1,186 @@
+# Issue 実装計画テンプレート
+
+`/plan` Phase 4 が Issue 本文に追記するテンプレート。元の Issue 本文（背景・目的・受け入れ条件）はそのまま残し、以下を追記する。
+
+```markdown
+---
+
+## 📚 リサーチ結果
+[調査した公式ドキュメント、ベストプラクティス、参考実装]
+
+## 🎯 影響範囲
+[変更対象ファイル、依存関係、副作用]
+
+### 依存先・波及範囲
+変更起点から下流まで、少なくとも以下を表で明記する。
+
+| 変更起点 | 波及先 | 確認内容 |
+|---------|--------|---------|
+| path/to/source | path/to/consumer | request/response/state/route の整合性 |
+
+### 非対象だが影響確認が必要な箇所
+- [このIssueでは直接実装しないが、壊していないことを確認すべき画面・API・導線]
+
+### 📄 DocDD更新対象
+変更対象から逆引きして、更新が必要な DocDD ドキュメントを特定する。
+
+| 変更レイヤー | 確認先 | 更新要否 |
+|------------|--------|:--------:|
+| API層（FastAPI routes） | `docs/7-axis/6_API/` の該当 yaml | ✅/— |
+| Model/Schema層 | `docs/7-axis/3_DM/` の該当 DM-*.md | ✅/— |
+| Service層（ビジネスルール変更） | `docs/7-axis/4_SR/` の該当 SR-*.md | ✅/— |
+| UseCase / Flow変更 | `docs/7-axis/2_UC/` の該当 UC-*.md | ✅/— |
+| TC / traceability | `docs/7-axis/7_TC/` + `docs/testing/traceability/` | ✅/— |
+
+## 🗺️ 証跡マッピング表
+
+<!-- 全行チェック方式: 全行コピーし、該当行に ✅ + 対象パス/理由、非該当行に — を記入する -->
+
+| 変更パス | 証跡カテゴリ | 必須証跡 | 自動検知 | 該当 | 対象パス/理由 |
+|---------|------------|---------|:--------:|:----:|-------------|
+| `apps/backend/app/modules/**/domain/**`, `apps/backend/app/modules/**/services/**` | backend-unit | ユニットテスト（pytest） | make test-backend | | |
+| `apps/backend/app/modules/**/infrastructure/**` | backend-integration | 統合テスト（DB/外部連携） | make test-backend | | |
+| `apps/backend/app/modules/**/presentation/**`, `apps/backend/app/shared/**/routes.py` | api-route | 統合テスト + API仕様書(6_API)更新 + caller全件確認 | make test-backend + 手動 | | |
+| `apps/backend/app/**/schemas/**`, `apps/frontend/**/_types/**` | api-contract | Frontend 型一致確認 | 手動 | | |
+| `apps/backend/app/kernel/**` | backend-core | ユニットテスト + 動作確認 | make test-backend + 手動 | | |
+| `apps/backend/alembic/versions/**` | migration-safety | up/down/up サイクル | CI | | |
+| `apps/frontend/app/**/page.tsx`, `apps/frontend/app/**/layout.tsx`, `apps/frontend/app/**/_containers/**`, `apps/frontend/app/**/_components/**`, `apps/frontend/src/components/**` | frontend-ui | Vitest OR ブラウザ目視 | make test-frontend / 手動 | | |
+| `apps/frontend/app/**/_hooks/**`, `apps/frontend/app/**/_lib/**` | frontend-logic | Vitest テスト必須 | make test-frontend | | |
+| `apps/frontend/src/lib/**`, `apps/frontend/src/store/**`, `apps/frontend/src/hooks/**` | frontend-shared | Vitest テスト必須 | make test-frontend | | |
+| `apps/frontend/app/**/globals.css`, `apps/frontend/tailwind.config.*`, `apps/frontend/postcss.config.*` | frontend-style | ブラウザ目視 | 手動 | | |
+| `docs/7-axis/**`, `docs/testing/traceability/**` | docdd | frontmatter + traceability | make traceability | | |
+| `scripts/**`, `Makefile*`, `*.config.*`, `.claude/hooks/**`, `.claude/settings.json`, `.github/**`, `terraform/**` | dx-config | 動作確認 + 既存テスト非破壊 | 手動 | | |
+| `.claude/commands/**`, `.claude/rules/**`, `.claude/skills/**`, `.claude/templates/**`, `.claude/references/**` | dx-docs | validate-claude + 目視確認 | make validate-claude | | |
+
+## 🖥️ UI State Matrix
+
+<!-- 適用条件: apps/frontend/app/**/page.tsx, apps/frontend/app/**/layout.tsx, apps/frontend/app/**/_containers/**, apps/frontend/app/**/_components/**, apps/frontend/src/components/** のいずれかを変更する場合に記入する。非該当なら「UI 変更なし — 適用外」と記載 -->
+<!-- N/A 可。ただし理由必須（例: N/A — 一覧ページのため送信中状態なし） -->
+
+| 状態 | トリガー | 期待 UI | 検証方法 | 該当 | 備考 |
+|------|---------|--------|:--------:|:----:|------|
+| Loading（初期表示） | データ初回フェッチ中 | Skeleton / Spinner | ブラウザ | | |
+| Loading（送信中） | フォーム送信 / アクション実行中 | ボタン disabled + 「処理中...」 | ブラウザ | | |
+| Empty（フィルタなし） | データ 0 件 | 「まだ○○がありません」 | ブラウザ | | |
+| Empty（フィルタあり） | 検索結果 0 件 | 「該当する○○がありません」 | ブラウザ | | |
+| Error（API / ネットワーク） | API 5xx / ネットワーク障害 | エラーメッセージ表示 | ブラウザ | | |
+| Error（バリデーション / ビジネスルール） | 入力不正 / 無効・期限切れ / ルール違反 | フィールドエラー or メッセージ | ブラウザ | | |
+| Success | 正常データ | 主導線の正常表示 | ブラウザ | | |
+| 権限なし | 権限不足 | 403 ページ or メッセージ | ブラウザ | | |
+| Route resilience | Reload / Back / URL欠落 | 状態復元 or 適切なフォールバック | ブラウザ | | |
+
+## 📏 サイズチェック
+| 指標 | 値 | 上限 | 判定 |
+|------|:--:|:----:|:----:|
+| 変更対象ファイル | ? | 20 | |
+| 実装タスク数 | ? | 8 | |
+| 起因 Issue / 負債 | ? | 1 | |
+| Phase 数 | ? | 1 | |
+| API/型の契約変更点 | ? | 3 | |
+| 下流呼び出し元数 | ? | 5 | |
+
+> 詳細: `.claude/rules/issue-sizing.md`
+
+## ⚠️ 重要ポイント
+[特に注意が必要な箇所 - 🔴Critical / 🟠High / 🟡Medium / 🟢Low]
+
+## 📋 実装タスク
+- [ ] タスク1
+- [ ] タスク2
+- [ ] タスク3
+
+## ✅ 検証定義
+
+| ID | 対象/観点 | コマンド/操作 | 期待結果 | PASS条件 | 備考/証跡 |
+|----|----------|-------------|---------|---------|---------|
+| V1 | frontmatter validator | `make validate-claude` | 全 PASS（warning は許容） | exit 0 | baseline モード |
+| V2 | traceability | `make traceability` | sample_map.json 整合 | exit 0 | DocDD 変更時に必須 |
+
+### TDD 判定（/develop 実装前に記録する）
+
+**空欄禁止**: 必須 / スキップ（理由）のどちらかを記載すること。空欄 = 証跡漏れとして扱う。
+
+| 項目 | 内容 |
+|------|------|
+| TDD 判定 | 必須 / スキップ（理由: ）|
+| 対象領域 | Backend service / API 契約変更 / Frontend pure logic / 認証 / 状態遷移 / バグ修正 / 該当なし |
+| 想定 RED コマンド | `make test-backend` / `make test-frontend` または focused pytest / vitest コマンド |
+| 想定 GREEN コマンド | `make test-backend` / `make test-frontend` または focused pytest / vitest コマンド |
+
+> **判断基準**: 後続 Issue で `.claude/rules/tdd-gate.md` を追加予定。当面は「外部連携・状態遷移・認証・API 契約変更を含むなら必須、それ以外は任意」の経験則で判定する。
+
+### Critical Path / Coverage expectation
+
+<!-- 判定基準（簡易リファレンス）:
+  Critical: 状態遷移・外部連携・callback・認証・申込導線を含む
+  Non-critical: 上記に該当しない（UI文言、CSS、DX等）
+  Mixed: Critical + Non-critical が混在
+  N/A 条件: .claude/ / docs/ のみの変更、デザイン調整のみ、文言修正のみ
+-->
+
+| 項目 | 内容 |
+|------|------|
+| Critical Path 判定 | Critical / Non-critical / Mixed / N/A |
+| Critical scope | Critical と判定した領域を列挙（Non-critical の場合は「なし」） |
+| 保護レイヤー | Unit / Integration / Browser evidence / Manual |
+| Coverage expectation | Critical = 100% / Non-critical touched scope = 90% / Mixed = critical 100% + touched non-critical 90% / N/A |
+| Focused test commands | /plan の計画から転記 |
+
+### Issue 固有の検証定義
+
+| ID | 対象/観点 | コマンド/操作 | 期待結果 | PASS条件 | 備考/証跡 |
+|----|----------|-------------|---------|---------|---------|
+| V3 | [対象] | [コマンド or 操作手順] | [期待する出力・状態] | [合否の判定基準] | [証跡URL・コマンド結果] |
+
+## 🔗 参照スキル
+- backend-patterns
+- frontend-patterns
+- testing-patterns
+- docdd-workflow
+- design
+
+> 一覧: `.claude/skills/README.md`
+
+## 📖 参照ドキュメント
+
+### プロジェクト内
+- [関連するプロジェクト内ドキュメントへのリンク]
+
+### 外部リファレンス
+- [調査した公式ドキュメント、ベストプラクティス記事へのリンク]
+- [参考にしたGitHubリポジトリ、技術ブログ等]
+
+## 🔄 後続Issue（必要な場合）
+[Phase 1 で確認した既存Issueを踏まえ、後続作業の方針を記載]
+
+判断結果:
+- [ ] 既存Issue #XXX に統合 / 新規Issue #XXX を作成 / 後続なし
+
+> 判断基準: PR差分300行以下なら統合OK。既存の関連Issueがあればそちらに統合を優先。
+
+**本Issue完了後に作成する後続Issue:**
+- [ ] 後続Issue-X: [内容]（なければ「後続なし」と記載）
+
+## ✅ 完了条件
+- [ ] 全テストがパス（`make test` または変更レイヤー対応の `make test-backend` / `make test-frontend`）
+- [ ] `make validate-claude` PASS
+- [ ] DocDD 更新が必要な場合は `make traceability` PASS
+- [ ] レビュー承認
+
+（ADRセクション - アーキテクチャ決定がある場合）
+（DocDD 7軸セクション - 新機能の場合）
+```
+
+---
+
+## 📋 後続 Issue で導入予定（forward reference の隔離）
+
+> 本テンプレートに含まれる検証定義表は最小構成。下記の項目は後続 Issue で skill / script として整備予定。本 Issue の `/plan` 段階では既存 rule のみを参照する。
+
+| 参照先（未存在） | 用途 | 予定 Issue |
+|--------------|------|----------|
+| `.claude/rules/tdd-gate.md` | TDD 判定の SSOT | 後続 Issue（4-2 想定） |
+| `.claude/skills/test-design/SKILL.md` | Critical Path 判定スキル | 後続 Issue（4-2 想定） |
+| `scripts/claude/verify-issue.sh`, `scripts/claude/quality-gate.sh` | Issue 単位の品質ゲート自動化 | 後続 Issue（5-1 / D-1 想定） |
+| `.claude/rules/multi-model-review.md` | 3 reviewer 並列レビュー | 後続 Issue（D-1 想定） |
+| `.claude/references/applicable-skills.md` | 適用スキル一覧の SSOT | 後続 Issue（4-1 想定） |

--- a/.claude/templates/verification-result-comment.md
+++ b/.claude/templates/verification-result-comment.md
@@ -1,0 +1,93 @@
+# 実装検証結果コメントテンプレート
+
+`/verify` の結果を Issue コメントに残すテンプレート。`/develop` の実装サマリーと併せて、PR 作成前の最終ゲートとなる。
+
+> **記法ルール**: 後続で evidence-checker（自動証跡検証）を導入する際の互換性を保つため、以下の記法を厳守する:
+> - **見出し**: `## 実装検証結果（/verify）` をそのまま使う（`/develop` 側の `完了時点` suffix を引きずらない）
+> - **TDD 判定行**: スキップ時は `スキップ（理由: ...）` と **同一セル内** に理由を書く
+> - **結果値**: `PASS` / `N/A` / `未解消` のみ（`✅ PASS` / `PASS（31/31）` / `PASS — 詳細` 等の装飾は付けない）
+> - **ブラウザ確認**: `PASS` / `Deferred` / `N/A` / `未解消` のみ
+
+```markdown
+## 実装検証結果（/verify）
+
+### Status
+- [完了 / 継続 / ブロッカーあり] — 1 行で記載
+- 次アクション: `/6 <N>`（PR 作成）/ ユーザー判断待ち（理由）など
+
+### 実行コンテキスト
+- セッション: [/develop と同一 / 別セッション]
+- 実行場所: [main / worktree]
+- worktree path: [.claude/worktrees/issue-<number>]（worktree の場合）
+- branch: [branch-name]
+
+### 検証サマリー
+- **Codex レビュー指摘件数**: 🔴 必須 X 件 / 🟡 推奨 Y 件 / 🟢 参考 Z 件 / ❌ 却下 W 件
+- **🔴 / 🟡 未解消**: [件数と要点。未解消なら本セッション内での対応方針を 1 行] / なし
+- **本セッション内で適用した修正**: [件数と主な変更。適用なしなら「なし」]
+
+### 品質チェック結果
+| 種別 | コマンド | 結果 |
+|------|---------|------|
+| バックエンド | `make test-backend` | PASS / FAIL（理由）/ N/A |
+| フロントエンド | `make test-frontend` | PASS / FAIL（理由）/ N/A |
+| 全体 | `make test` | PASS / FAIL（理由）/ N/A |
+| frontmatter | `make validate-claude` | PASS / FAIL（理由）/ N/A |
+| traceability | `make traceability` | PASS / FAIL（理由）/ N/A |
+
+### ブラウザ確認（軽量ヘルスチェック）
+| 項目 | 結果 | 備考 |
+|------|------|------|
+| 主要導線の手動確認 | PASS / Deferred / N/A / 未解消 | [入口 → 完了までの導線を確認したか] |
+| Console error | PASS / Deferred / N/A / 未解消 | [新たな error / warn の有無] |
+| Network 4xx/5xx | PASS / Deferred / N/A / 未解消 | [意図しないエラーの有無] |
+
+> **運用の基本**: `/verify` ではランタイム異常のヘルスチェックのみを行う。深い目視確認・スクリーンショット比較は別途実施する。
+> **N/A にしていいのは**: API / バックグラウンド処理 / 設定ファイルのみの変更でブラウザ導線が存在しない場合のみ。
+
+### TDD 証跡
+| 項目 | 内容 |
+|------|------|
+| TDD 判定 | 必須 / スキップ（理由: ）|
+| 追加したテスト | `/develop の TDD 証跡から転記` |
+| RED コマンド | `/develop の TDD 証跡から転記` |
+| RED 結果 | `/develop の TDD 証跡から転記`（例: FAILED: 1 failed）|
+| GREEN コマンド | `/develop の TDD 証跡から転記` |
+| GREEN 結果 | `/develop の TDD 証跡から転記`（例: PASSED: 1 passed）|
+| /verify での再確認 | PASS / N/A（スキップの場合）/ 未解消 |
+
+### Coverage 証跡
+| 項目 | 内容 |
+|------|------|
+| Critical Path 判定 | /develop の Coverage 証跡から転記 |
+| 保護レイヤー | /develop の Coverage 証跡から転記 |
+| Coverage expectation | /develop の Coverage 証跡から転記 |
+| Focused test commands | /develop の Coverage 証跡から転記 |
+| 結果 | PASS / N/A / 未解消 |
+
+### DocDD / TC / Traceability
+- `make traceability`: [PASS / FAIL（理由）/ N/A（DocDD 変更なし）]
+- 更新した DocDD / TC / traceability map: [ファイル名のリスト。更新なしなら「なし」]
+
+### Codex レビュー監査証跡（サマリのみ）
+| 項目 | 内容 |
+|------|------|
+| Codex 実行コマンド | `codex review --base main` / 実行省略（理由） |
+| exit status | [0 / エラー内容 / 未実行] |
+| 所要時間 | [秒。未実行なら N/A] |
+| 指摘の対応サマリ | 🔴 必須 → [対応内容] / 🟡 推奨 → [採否と理由] |
+
+### 未解消 / 先送り
+[未対応の指摘・テスト失敗・実装漏れがあれば明記。なければ「なし」]
+```
+
+---
+
+## 📋 後続 Issue で導入予定（forward reference の隔離）
+
+| 参照先（未存在） | 用途 | 予定 Issue |
+|--------------|------|----------|
+| evidence-checker（`scripts/claude/verify_issue_evidence.py` 相当） | コメント記法の自動検証 | 後続 Issue（5-1 / D-1 想定） |
+| `.claude/rules/multi-model-review.md` | Codex + Claude SA × 2 の 3 reviewer 並列レビュー | 後続 Issue（D-1 想定）|
+| ephemeral session memory writer | raw 3-reviewer 出力の退避 | 後続 Issue（D-X 想定）|
+| `/screen-verify` + TC YAML 自動実行 | post-merge STG ブラウザ検証 | 後続 Issue（D-X 想定）|

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 .specstory/**
 
 .cursorindexingignore
+
+# Worktrees (canonical /worktree creates these)
+.claude/worktrees/


### PR DESCRIPTION
## 概要

Wave 2 / Phase 2-1。SubsCore で確立された canonical コマンド体系（`/issue → /worktree → /plan → /develop → /verify → /review → /pr → /merge`）の **前半 5 本** と、それらが直接参照する **コア依存テンプレ・スキル 4 件** を追加する。

旧コマンド（`/1`〜`/7`, `/a`〜`/c`）は **削除せず並存**（物理削除は Issue 2-3 で実施、CLAUDE.md / README ポインタ化は Issue 2-4 で実施）。本 PR は **追加のみ**。

## 関連 Issue

Closes #34

## 変更点

### 新規コマンド 5 件（`.claude/commands/`）

| ファイル | 役割 | 統合元 |
|---------|------|-------|
| `issue.md` | Issue 作成（canonical labels 第一候補 + legacy alias 併記） | `1.create-issue.md` 相当 |
| `worktree.md` | Worktree 作成 + ブランチセットアップ統合（CLI-first / 自己参照ガード） | `a.create-worktree.md` + `b.move-to-worktree.md` + `3.create-branch.md` |
| `plan.md` | 実装計画立案（Codex 単独レビュー、Pencil は `design` スキル経由） | `2.plan-github-issue.md` 相当 |
| `develop.md` | 実装フェーズ（Phase 4 高リスク変更を汎用スケルトン化） | `4.fix-github-issue.md` 相当 |
| `verify.md` | 実装検証（Step 1 で working-tree + untracked を取得、責任分離） | `5.verify-implementation.md` 相当 |

すべて `disable-model-invocation: true` + `description` 必須 frontmatter、引数を取る 4 コマンドは `argument-hint: "<issue-number>"` を追加。

### 新規テンプレ 3 件 + スキル 1 件

- `.claude/templates/issue-implementation-plan.md` — `/plan` Phase 4 用
- `.claude/templates/implementation-summary-comment.md` — `/develop` Phase 5 用
- `.claude/templates/verification-result-comment.md` — `/verify` Step 6 用
- `.claude/skills/parallel-development/SKILL.md` — `/worktree` `/plan` の判定 SSOT

memory writer / evidence-checker 互換性厳守 / 3 reviewer 並列レビューはすべて後続 Issue（D-1, D-X）に隔離。

### 設定変更 1 件

- `.gitignore` に `.claude/worktrees/` を追加

## SubsCore 由来要素の整理

- billing / SBPS / Paygent / BankPay / sco-group / Project OS / `PVT_kw...` ID は **すべて削除**（V3 で 0 hit 確認済）
- `EnterWorktree` MCP ツールは使わず `git worktree add` CLI 経由（V7、cli-first.md 準拠）
- `npm install` は `npm --prefix apps/frontend install` または `make install-dev`（V10、root に package.json なし）
- env symlink は **allowlist + 存在確認 + ユーザー確認 + `.env.example` 優先**（V11、`apps/backend/.env` と `apps/frontend/.env.local` の 2 ファイル限定）

## Codex レビュー対応（Issue #34 コメント参照）

- **計画レビュー（/plan Phase 5）**: 🔴 4 / 🟡 5 / 🟢 1 → 全件採用、計画 v2 に反映
- **コードレビュー（/verify Step 5）**: 🔴/P1 2 件 → 本セッション内で全 2 件即修正
  - `verify.md` Step 1: `MERGE_BASE...HEAD` だけでは未コミット変更が見えない問題 → working-tree diff + untracked files 取得を追加
  - `worktree.md` Step 6: main checkout から実行されると `.env` を自己参照 symlink で破壊するリスク → `WORKTREE_ROOT == MAIN_ROOT` 比較ガードを冒頭と `setup_env` 内に二重設置

## 検証結果

- [x] `/5`（`/verify` 移行前の `5.verify-implementation`）で検証済み
- [x] V1〜V11 全項目 PASS（Issue #34 のコメント「実装検証結果」参照）
  - V1 `make validate-claude`: 20 passed / 0 failed / 21 warnings（`args` 欠落のみ・baseline 許容）
  - V2 `make traceability`: PASS
  - V3 SubsCore 固有要素混入: 0 hit（rg + grep -F 両方）
  - V4〜V11: 全 PASS
- [x] CLAUDE.md 更新チェック済み — **本 PR では更新しない**（コマンド一覧の更新は Issue 2-4 にスコープアウト済み。Issue 34 受け入れ条件にも CLAUDE.md は含まれない）
- [x] 旧コマンド 10 ファイルは削除せず並存（V5 で確認済）

## 後続 Issue（依存解消）

- **Issue 2-2**: canonical 後半 6 本（pr / merge / review / tdd / brainstorm / discard-worktree）
- **Issue 2-3**: 補助コマンド frontmatter + legacy alias shim + 旧コマンド削除
- **Issue 2-4**: CLAUDE.md ポインタ化 + rules/templates/README/bootstrap 参照更新 + migration guide