### PR TITLE
feat(skills): import TDD / verification core skills + tdd-gate (#54)

### DIFF
--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -32,11 +32,11 @@ GitHub Issue $ARGUMENTS の実装を行ってください。
    | DocDD documents / 7-axis | docdd-workflow | `.claude/skills/docdd-workflow/SKILL.md` |
 
 4. **TDD 証跡を確認する**（`/plan` 検証定義の「TDD 判定」欄）:
-   - `TDD 必須` → RED テストを先行作成して FAILED 結果を確認してから実装へ
+   - `TDD 必須` → RED テストを先行作成して FAILED 結果を確認してから実装へ（`/tdd $ARGUMENTS` を別フェーズで起動するか、本コマンド内で RED → GREEN を進める）
    - `TDD スキップ（理由あり）` → スキップ理由をサマリに転記して実装へ
    - 空欄 → **証跡漏れ** として判断を明示してから実装へ
 
-> 後続 Issue で TDD 専用コマンド `/tdd` および `.claude/rules/tdd-gate.md` を導入予定。本コマンドでは TDD 必須判定の場合も `/develop` 内で RED → GREEN を進める。
+> 判定基準 SSOT: [`.claude/rules/tdd-gate.md`](../rules/tdd-gate.md)。RED-GREEN サイクル・パターン集・証跡フォーマットは [`.claude/skills/tdd-workflow/SKILL.md`](../skills/tdd-workflow/SKILL.md) を参照。
 
 ### Phase 2: 実装
 
@@ -105,13 +105,15 @@ Issue #XXX をチームで実装して。
 
 #### 実行ルール
 
-- **Backend を触ったら** `make test-backend` だけで終わらせず、変更したモジュールに紐づく focused pytest（`pytest apps/backend/tests/.../test_xxx.py::test_name`）も実行する
+- **Backend を触ったら** `make test-backend` だけで終わらせず、変更したモジュールに紐づく focused pytest（`PYTHONPATH=apps/backend pytest tests/backend/.../test_xxx.py::test_name -v`）も実行する
 - **API 契約を変えたら**、client / hook / container / 次画面 / callback handler まで追って確認する
 - **DocDD を更新したら** `make traceability` を実行する
 - **`.claude/` の dx-docs を変更したら** `make validate-claude` を実行する
 - ブラウザ結合確認は `/verify` で軽量ヘルスチェック（Console / Network エラーチェック）として実施する
 
 #### 失敗扱いにするもの
+
+完了主張前のゲート（5 ステップ: IDENTIFY / RUN / READ / VERIFY / CLAIM）の SSOT は [`.claude/skills/verification-before-completion/SKILL.md`](../skills/verification-before-completion/SKILL.md)。以下を「成功」扱いにしない:
 
 - `0 selected`
 - `all skipped`
@@ -250,11 +252,7 @@ gh issue edit $ARGUMENTS --body-file /tmp/issue_$ARGUMENTS.md
 
 | 参照先（未存在） | 用途 | 予定 Issue |
 |--------------|------|----------|
-| `/tdd` コマンド | TDD 専用コマンド（RED テスト先行作成） | 後続 Issue（4-2 想定） |
-| `.claude/rules/tdd-gate.md` | TDD 判定の SSOT | 後続 Issue（4-2 想定） |
-| `.claude/skills/tdd-workflow/SKILL.md` | TDD 実行スキル | 後続 Issue（4-2 想定） |
 | `.claude/skills/systematic-debugging/SKILL.md` | バグ修正の体系化スキル | 後続 Issue（4-3 想定） |
-| `.claude/skills/verification-before-completion/SKILL.md` | 完了主張前のゲート | 後続 Issue（4-2 想定） |
 | `make quality-gate` ターゲット | 品質ゲート一括実行 | 後続 Issue（5-1 想定） |
 | `/screen-verify` + TC YAML 自動実行 | post-merge ステージング検証 | 後続 Issue（D-X 想定） |
 

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -102,14 +102,18 @@ Phase 1.2 の依存先トレースが完了した時点で、変更パスから�
 
 ### Phase 1.3: Critical Path 判定（必須）
 
-変更対象を以下の基準で評価する:
+判定基準・保護レイヤー選択・Coverage expectation の SSOT は [`.claude/skills/test-design/SKILL.md`](../skills/test-design/SKILL.md)。Critical / Mixed と判定した場合は同 skill を **Read** して、保護レイヤーと Focused test commands を Critical Path テーブルへ転記する。
+
+変更対象を以下の基準で評価する（早見表 — 詳細は test-design SKILL）:
 
 - **Critical**: 状態遷移・外部連携・callback・認証・申込導線を含む
 - **Non-critical**: 上記に該当しない（UI 文言、CSS、DX ツーリング等）
 - **Mixed**: Critical と Non-critical が混在
-- **N/A**: `.claude/` / `docs/` のみの変更、文言修正のみ
+
+> **N/A は Critical Path 判定の値ではなく、Coverage expectation の例外**。`.claude/` / `docs/` のみの変更・文言修正のみで実行コードを含まない場合、`Critical Path 判定 = Non-critical` + `Coverage expectation = N/A` と記入する（Critical / Mixed では N/A を選択不可。SSOT: [`.claude/skills/test-design/SKILL.md`](../skills/test-design/SKILL.md) の N/A 条件節）。
 
 判定結果に応じて Coverage expectation・focused test commands を Issue 本文の Critical Path テーブルに記入する。
+TDD 必須 / スキップ判定の SSOT は [`.claude/rules/tdd-gate.md`](../rules/tdd-gate.md)（Critical 領域は原則 TDD 必須）。
 
 ### Phase 1.5: UI 設計の確認（UI 変更を伴う場合）
 
@@ -223,7 +227,7 @@ UI 変更を伴う Issue の場合は、計画前にデザインを検討:
 
 テンプレを反映する際、以下の 3 ロジックで該当セクションを出し分ける:
 
-1. **TDD 判定 row の出し分け**:
+1. **TDD 判定 row の出し分け**（判定 SSOT: [`.claude/rules/tdd-gate.md`](../rules/tdd-gate.md)）:
    - **TDD 必須** の場合: 「想定 RED コマンド」「想定 GREEN コマンド」に focused pytest / vitest コマンドを**具体値**で記入
    - **TDD スキップ** の場合: 同じ row に「該当なし」と記入し、判定欄に `スキップ（理由: <one-liner>）` と記入
    - **空欄禁止**: 必須 / スキップどちらかを必ず記入する。空欄 = 証跡漏れとして扱う
@@ -407,7 +411,5 @@ Issue 本文を仕様固定済み計画に更新し、Codex 計画レビュー�
 | 参照先（未存在） | 用途 | 予定 Issue |
 |--------------|------|----------|
 | `.claude/rules/multi-model-review.md` | Codex + Claude SA × 2 の 3 reviewer 並列レビュー | 後続 Issue（D-1 想定） |
-| `.claude/skills/test-design/SKILL.md` | Critical Path 判定スキル化 | 後続 Issue（4-2 想定） |
-| `.claude/rules/tdd-gate.md` | TDD 判定の SSOT | 後続 Issue（4-2 想定） |
 
 Remember to use the GitHub CLI (`gh`) for all GitHub-related tasks.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -56,7 +56,7 @@ if ! gh issue view $ARGUMENTS --comments | grep -qE "実装検証結果（/verif
 fi
 ```
 
-> **逃げない**: `/verify` を飛ばしての PR 作成は禁止。完了品質ルール（`.claude/rules/completion-quality.md`）に従い、検証コメントが揃ってから先に進む。Pre-flight gate は **warning ではなく hard failure（exit 1）** にしてゲートを担保する。
+> **逃げない**: `/verify` を飛ばしての PR 作成は禁止。完了品質ルール（[`.claude/rules/completion-quality.md`](../rules/completion-quality.md)）と完了主張前のゲート SSOT（[`.claude/skills/verification-before-completion/SKILL.md`](../skills/verification-before-completion/SKILL.md)）に従い、検証コメントが揃ってから先に進む。Pre-flight gate は **warning ではなく hard failure（exit 1）** にしてゲートを担保する。
 
 ### Step 2: 差分確認
 
@@ -261,7 +261,6 @@ PR を作成した。`/merge` は **main 側のターミナル** に切り替え
 
 | 参照先（未存在） | 用途 | 予定 Issue |
 |--------------|------|----------|
-| `.claude/skills/verification-before-completion/SKILL.md` | Pre-flight gate の SSOT | 後続 Issue（4-2 想定） |
 | `make verify-issue` / `make quality-gate` | Pre-flight gate の自動化 | 後続 Issue（5-1 想定） |
 | `.claude/policies/landing-path-state.yaml` + validator | UI 変更時の auto close 抑止（`screen-verify` 連携） | **持ち込まない**（`screen-verify` がスコープ外のため） |
 | `roadmap.md` 更新ステップ | リリース計画との突合 | starter に roadmap なし。**持ち込まない** |

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -30,7 +30,7 @@ Issue #$ARGUMENTS の TDD（Test-Driven Development）ガード付き実装を�
 
 ### Step 1: TDD 判定を確認
 
-`/plan` の検証定義から TDD 判定を読み取る。
+`/plan` の検証定義から TDD 判定を読み取る。判定基準の SSOT は [`.claude/rules/tdd-gate.md`](../rules/tdd-gate.md)。
 
 ```bash
 # Issue 本文の TDD 判定を確認
@@ -58,17 +58,18 @@ gh issue view $ARGUMENTS --json body --jq .body | grep -A 5 "Focused test comman
 
 | 項目 | 内容 |
 |------|------|
-| 想定 RED コマンド | `pytest apps/backend/tests/.../test_xxx.py::test_new_case` |
-| 想定 GREEN コマンド | `pytest apps/backend/tests/.../test_xxx.py::test_new_case` |
+| 想定 RED コマンド | `PYTHONPATH=apps/backend pytest tests/backend/.../test_xxx.py::test_new_case -v` |
+| 想定 GREEN コマンド | `PYTHONPATH=apps/backend pytest tests/backend/.../test_xxx.py::test_new_case -v` |
 
 ### Step 3: Failing test を先行作成
 
 実装本体には触れず、**期待挙動を表現する Failing test** だけを書く。
+パターン集（新規ロジック / バグ修正 / 状態遷移 / API / parametrize）と heredoc 利用判断は [`.claude/skills/tdd-workflow/SKILL.md`](../skills/tdd-workflow/SKILL.md) を参照。
 
 | レイヤー | パターン | 補足 |
 |---------|---------|------|
-| Backend (pytest) | `apps/backend/tests/<unit\|integration>/test_xxx.py` に `test_新挙動` を追加 | `.claude/skills/testing-patterns/SKILL.md` 参照 |
-| Frontend (Vitest) | `apps/frontend/src/.../__tests__/xxx.test.ts(x)` に新ケースを追加 | `.claude/skills/testing-patterns/SKILL.md` 参照 |
+| Backend (pytest) | `tests/backend/<unit\|integration>/test_xxx.py` に `test_新挙動` を追加 | [`.claude/skills/tdd-workflow/SKILL.md`](../skills/tdd-workflow/SKILL.md) / [`.claude/skills/testing-patterns/SKILL.md`](../skills/testing-patterns/SKILL.md) 参照 |
+| Frontend (Vitest) | `tests/frontend/unit/xxx.test.ts(x)` に新ケースを追加 | [`.claude/skills/tdd-workflow/SKILL.md`](../skills/tdd-workflow/SKILL.md) / [`.claude/skills/testing-patterns/SKILL.md`](../skills/testing-patterns/SKILL.md) 参照 |
 
 **禁止事項**:
 - ❌ 実装本体（`apps/backend/app/...` の domain/service/route）には一切触れない
@@ -78,13 +79,14 @@ gh issue view $ARGUMENTS --json body --jq .body | grep -A 5 "Focused test comman
 ### Step 4: RED 確認（Failing 結果を取る）
 
 新規テストが想定どおり FAILED で落ちることを確認する。
+「`0 selected` / `all skipped` を成功扱いにしない」など完了判定の SSOT は [`.claude/skills/verification-before-completion/SKILL.md`](../skills/verification-before-completion/SKILL.md) を参照。
 
 ```bash
 # Backend 例
-pytest apps/backend/tests/<path>/test_xxx.py::test_new_case -v
+PYTHONPATH=apps/backend pytest tests/backend/<path>/test_xxx.py::test_new_case -v
 
 # Frontend 例
-cd apps/frontend && npx vitest run src/.../__tests__/xxx.test.ts -t "test_new_case"
+cd apps/frontend && npx vitest run ../../tests/frontend/unit/xxx.test.ts -t "test_new_case"
 ```
 
 **RED として有効な結果**:
@@ -110,17 +112,17 @@ gh issue comment $ARGUMENTS --body "$(cat <<'EOF'
 - 対象領域: [Backend / Frontend / 両方]
 
 ### 追加したテスト
-- `apps/backend/tests/<path>/test_xxx.py::test_new_case`（Failing で先行追加）
+- `tests/backend/<path>/test_xxx.py::test_new_case`（Failing で先行追加）
 - [複数ある場合は箇条書き]
 
 ### RED コマンド
 \`\`\`bash
-pytest apps/backend/tests/<path>/test_xxx.py::test_new_case -v
+PYTHONPATH=apps/backend pytest tests/backend/<path>/test_xxx.py::test_new_case -v
 \`\`\`
 
 ### RED 結果
 \`\`\`
-FAILED apps/backend/tests/<path>/test_xxx.py::test_new_case
+FAILED tests/backend/<path>/test_xxx.py::test_new_case
 - AssertionError / ImportError / 等の要点を 1〜3 行
 - 1 failed in X.Xs
 \`\`\`
@@ -134,6 +136,8 @@ EOF
 
 > **記法ルール**: `/develop` Phase 5 / `/verify` Step 6 で証跡を確認するため、見出し `## TDD RED 証跡（/tdd 完了時点）` をそのまま使う。コマンドと結果はコードブロックで囲む。
 > **ファイル参照**: 結果が長い場合は `/tmp/tdd_red_$ARGUMENTS.txt` に書き出して `gh issue comment --body-file` で投稿してもよい。
+
+> **記法・ガイドライン SSOT**: 証跡フォーマット詳細は [`.claude/skills/tdd-workflow/SKILL.md`](../skills/tdd-workflow/SKILL.md)（証跡記録セクション）。完了主張前のゲート（5 ステップ）は [`.claude/skills/verification-before-completion/SKILL.md`](../skills/verification-before-completion/SKILL.md)。
 
 ### Step 6: `/develop` への引き渡し
 
@@ -215,9 +219,6 @@ RED 証跡を Issue コメントに残した。`/develop` で GREEN を達成す
 
 | 参照先（未存在） | 用途 | 予定 Issue |
 |--------------|------|----------|
-| `.claude/rules/tdd-gate.md` | TDD 判定の SSOT（必須判定基準・スキップ条件） | 後続 Issue（4-2 想定） |
-| `.claude/skills/tdd-workflow/SKILL.md` | TDD 実行スキル（RED-GREEN-Refactor の詳細手順） | 後続 Issue（4-2 想定） |
-| `.claude/skills/verification-before-completion/SKILL.md` | RED 完了主張前のゲート | 後続 Issue（4-2 想定） |
 | failure-escalation Level 3 hook | RED が連続 3 回失敗した場合の停止 hook | 後続 Issue（1-1 baseline 拡張 想定） |
 
 Remember to use the GitHub CLI (`gh`) for all GitHub-related tasks.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -103,6 +103,7 @@ make traceability
 #### Step 3-2: TDD 証跡確認
 
 `/develop` の実装サマリーの「TDD 証跡」テーブルを確認する。
+判定基準 SSOT: [`.claude/rules/tdd-gate.md`](../rules/tdd-gate.md) / RED-GREEN 証跡フォーマット SSOT: [`.claude/skills/tdd-workflow/SKILL.md`](../skills/tdd-workflow/SKILL.md)。
 
 | 確認項目 | PASS 条件 |
 |---------|---------|
@@ -116,7 +117,9 @@ make traceability
 
 #### Step 3-3: 失敗扱いにする例
 
-- `pytest` が marker 条件で全 deselect
+完了主張前のゲート（5 ステップ）と禁止表現の SSOT は [`.claude/skills/verification-before-completion/SKILL.md`](../skills/verification-before-completion/SKILL.md)。以下を「成功」扱いにしない:
+
+- `pytest` が path / pattern 指定ミスで全 deselect（`0 selected`）
 - `npm run xxx` が script 不在で失敗
 - `make test-backend` / `make test-frontend` / `make validate-claude` / `make traceability` が FAIL
 - 実行したと書いてあるが結果が残っていない

--- a/.claude/references/applicable-skills.md
+++ b/.claude/references/applicable-skills.md
@@ -27,6 +27,9 @@ Issue の内容に応じて、該当するスキルだけを読み込む SSOT。
 | Organizing agent teams / context-fresh strategy (`/plan`, `/develop`, `/verify`, `/review`) | agent-teams | [`.claude/skills/agent-teams/SKILL.md`](../skills/agent-teams/SKILL.md) |
 | Parallel development with worktrees (`/worktree`, `/merge`, `/discard-worktree`) | parallel-development | [`.claude/skills/parallel-development/SKILL.md`](../skills/parallel-development/SKILL.md) |
 | `/verify` Step 1 input capture (issue number validation / merge-base diff / execution context) | verify-input-capture | [`.claude/skills/verify-input-capture/SKILL.md`](../skills/verify-input-capture/SKILL.md) |
+| TDD workflow / RED-GREEN cycle / 証跡フォーマット (`/tdd`, `/develop`, `/verify`) | tdd-workflow | [`.claude/skills/tdd-workflow/SKILL.md`](../skills/tdd-workflow/SKILL.md) |
+| Critical Path 判定・保護レイヤー選択・Coverage expectation (`/plan` Phase 1.3 で Critical/Mixed と判定された場合) | test-design | [`.claude/skills/test-design/SKILL.md`](../skills/test-design/SKILL.md) |
+| 完了主張前の 5 ステップゲート（IDENTIFY/RUN/READ/VERIFY/CLAIM） (`/develop` Phase 3, `/verify`, `/pr`) | verification-before-completion | [`.claude/skills/verification-before-completion/SKILL.md`](../skills/verification-before-completion/SKILL.md) |
 
 ## 使い方
 

--- a/.claude/rules/tdd-gate.md
+++ b/.claude/rules/tdd-gate.md
@@ -1,0 +1,40 @@
+# TDD ゲートルール
+
+高リスク領域では **RED → GREEN の証跡** がない限り完了扱いにしない。
+RED-GREEN サイクル・証跡チェーン・コマンド・パターンの詳細は [`.claude/skills/tdd-workflow/SKILL.md`](../skills/tdd-workflow/SKILL.md) を参照。
+
+## TDD 必須（RED テスト先行が必要）
+
+| 領域 | 例 |
+|------|-----|
+| Backend の domain / service / api | service 新設、ビジネスロジック変更 |
+| Frontend pure logic（validation / mapper / store / util） | Zod スキーマ変更、Zustand store ロジック変更 |
+| 認証・権限 | JWT 検証、権限チェック |
+| 状態遷移を含む業務フロー | 申込・契約・決済フロー、ステータス変更 |
+| API 契約変更 | request / response / status code 変更 |
+| バグ修正（再現できるもの） | 再現テストを先に書く |
+
+## TDD スキップ可（理由を必ず記録。空欄 = 証跡漏れ）
+
+| 理由 | 例 |
+|------|-----|
+| Pencil 調整のみ / Frontend Presentational のみ | デザイン・CSS・文言変更のみ |
+| 既存テストで保護されている配線変更（テスト名を明記） | import パス変更、型エイリアス追加 |
+| `.claude/` 内の非実行物のみの変更 | commands・rules・skills・templates・references。**hooks / settings.json / scripts は対象外（挙動変更を含む場合は TDD 必須）** |
+
+> **原則**: 迷ったら TDD 必須として扱う。
+
+## Critical Path との連携
+
+- Critical Path = Critical → 対象領域は原則 TDD 必須
+- Critical Path = Non-critical → 上記の判断基準に従う
+- 詳細: [`.claude/skills/test-design/SKILL.md`](../skills/test-design/SKILL.md)
+
+## 関連ファイル
+
+- [skills/tdd-workflow/SKILL.md](../skills/tdd-workflow/SKILL.md) - RED-GREEN サイクル・証跡チェーン・パターン集
+- [skills/test-design/SKILL.md](../skills/test-design/SKILL.md) - Critical Path 判定・保護レイヤー選択
+- [skills/verification-before-completion/SKILL.md](../skills/verification-before-completion/SKILL.md) - 完了主張前のゲート
+- [skills/testing-patterns/SKILL.md](../skills/testing-patterns/SKILL.md) - DB フィクスチャ・CI 戦略
+- [commands/develop.md](../commands/develop.md) - `/develop` 実装フロー
+- [commands/tdd.md](../commands/tdd.md) - `/tdd` RED テスト先行

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -36,6 +36,9 @@ Claude Code が特定のドメインや技術パターンを適用する際に�
 | [agent-teams](./agent-teams/SKILL.md) | エージェントチーム運用（粒度判断 / コンテキストフレッシュ / 検証テンプレ） |
 | [parallel-development](./parallel-development/SKILL.md) | 並列開発（Worktree）運用ルール |
 | [verify-input-capture](./verify-input-capture/SKILL.md) | `/verify` Step 1 の入力固定（Issue 番号検証 / merge-base diff / 実行コンテキスト） |
+| [tdd-workflow](./tdd-workflow/SKILL.md) | TDD（RED-GREEN-REFACTOR）サイクル / pytest・Vitest パターン / 証跡フォーマット |
+| [test-design](./test-design/SKILL.md) | Critical Path 判定 / 保護レイヤー選択 / Coverage expectation（`/plan` Critical/Mixed 時に追加読込） |
+| [verification-before-completion](./verification-before-completion/SKILL.md) | 完了主張前の 5 ステップゲート（IDENTIFY / RUN / READ / VERIFY / CLAIM） |
 
 ### 外部 taxonomy 採用領域（prefix 命名）
 

--- a/.claude/skills/tdd-workflow/SKILL.md
+++ b/.claude/skills/tdd-workflow/SKILL.md
@@ -1,0 +1,394 @@
+---
+name: tdd-workflow
+description: |
+  pytest / Vitest TDD（テスト駆動開発）ワークフローを支援。
+  RED-GREEN-REFACTOR サイクル、RED 証跡フォーマット、Backend (pytest) / Frontend (Vitest) のパターン集を提供。
+  `/tdd` `/develop` `/verify` から参照される。
+---
+
+# TDD ワークフロースキル
+
+## 概要
+
+docdd-starters における TDD の実践パターン。
+Backend は `make test-backend`（pytest）、Frontend は `make test-frontend`（Vitest）を使用する。
+`0 selected` / `all skipped` / `no test files found` を「成功」扱いにしない。
+
+判断基準（TDD 必須 / スキップ）は [`.claude/rules/tdd-gate.md`](../../rules/tdd-gate.md) を参照。
+
+---
+
+## 本リポジトリの pytest 前提（必須知識）
+
+**本リポジトリの pytest marker は `tc_id` のみ**（`apps/backend/pytest.ini` 参照）。
+SubsCore 由来の `unit` / `integration` / `integration_local` marker は本リポジトリでは **適用しない**。
+
+代わりに **テスト配置ディレクトリ** で unit / integration を分ける:
+
+| 種別 | 配置 | コマンド |
+|------|------|----------|
+| 単体テスト | `tests/backend/unit/` | `make test-backend`（全実行）/ `PYTHONPATH=apps/backend pytest tests/backend/unit/test_xxx.py -v`（focused） |
+| 統合テスト | `tests/backend/integration/` | `make test-backend`（全実行）/ `PYTHONPATH=apps/backend pytest tests/backend/integration/test_xxx.py -v`（focused） |
+| 全テスト | `tests/backend/` | `make test-backend` |
+
+> **`PYTHONPATH=apps/backend` が必須**: `apps/backend/pytest.ini` の `pythonpath = app` は pytest 設定。Makefile 経由でない focused 実行では環境変数で同等の解決を行う。
+
+### 正しいコマンド一覧
+
+| 用途 | コマンド | 備考 |
+|------|---------|------|
+| 全 backend テスト | `make test-backend` | 推奨（CI と同一） |
+| 全 frontend テスト | `make test-frontend` | 推奨（CI と同一） |
+| 全テスト | `make test` | backend + frontend |
+| 特定ファイル（unit） | `PYTHONPATH=apps/backend pytest tests/backend/unit/test_xxx.py -v` | focused |
+| 特定テスト関数 | `PYTHONPATH=apps/backend pytest tests/backend/unit/test_xxx.py::test_func -v` | focused |
+| integration の特定テスト | `PYTHONPATH=apps/backend pytest tests/backend/integration/test_xxx.py -v` | DB 起動が前提 |
+| Frontend 特定ファイル | `cd apps/frontend && npx vitest run ../../tests/frontend/unit/xxx.test.ts` | focused |
+| dx-docs（`.claude/`）変更時 | `make validate-claude` | frontmatter 検証 |
+| DocDD 変更時 | `make traceability` | 7 軸 map 整合性 |
+
+> 補足: `make test-unit` / `make test-integration` / `make quality-gate` などのターゲットは **本リポジトリには存在しない**（後続 Issue 5-1 想定）。skill / command でこれらのターゲットを案内しないこと。
+
+---
+
+## RED-GREEN サイクル
+
+### フロー
+
+```
+1. 失敗するテストを書く（RED）
+2. RED を確認する（make test-backend → FAILED を目視）
+3. 最小実装を書く（GREEN にする）
+4. GREEN を確認する（make test-backend → PASSED）
+5. 必要なら整理（REFACTOR → GREEN を維持）
+```
+
+### ポイント
+
+- **最小実装**: テストを通すだけの最小コードを書く。追加機能は次の RED から始める
+- **1 サイクル 1 概念**: 1 つのテストが 1 つの振る舞いを検証する
+- **RED は意図的に**: 偶然 RED になるのではなく、意図した失敗を確認する
+
+---
+
+## テストファイル作成時のツール選択
+
+### Write / Edit がブロックされるパターン
+
+`.claude/settings.json` の `permissions.deny` と harness の directory permission で以下がブロックされ得る:
+
+| glob パターン | Write | Edit | MultiEdit | 備考 |
+|-------------|:---:|:---:|:---:|------|
+| `test_*.py` / `conftest.py` | ⚠️ | ❌ | ❌ | `conftest.py` は Write も deny されることがある |
+| `*.test.*` / `*.spec.*` | ✅ | ❌ | ❌ | FE テスト（`.test.tsx` 等） |
+| `vitest.config*` / `tsconfig.json` / `biome.json` / `pytest.ini` | ❌ | ❌ | ❌ | 設定ファイルは完全 deny |
+| worktree 内の `apps/**` | ⚠️ | ⚠️ | ⚠️ | directory permission で `Write` が denied になる場合あり |
+
+### 判断フロー
+
+```
+新規テストファイルを作成したい
+  └→ 既存テストの改変か？
+       └→ Yes → 置換ブロックを提示してユーザー側で反映（heredoc で上書きしない。弱体化リスク）
+       └→ No（純粋な新規 RED テスト）
+            └→ Write を試す
+                └→ 通った → OK
+                └→ denied → Bash heredoc を使う
+                     └→ `cat > tests/backend/unit/test_xxx.py << 'EOF' ... EOF`
+                     └→ `wc -l tests/backend/unit/test_xxx.py` で保存確認
+                     └→ Bash も denied → `touch <path>` + 内容提示 → ユーザー貼付
+
+設定ファイル（vitest.config.ts / pytest.ini 等）を変更したい
+  └→ Write / Edit 両方 deny → パッチ内容を提示してユーザー側で反映（heredoc も使わない）
+```
+
+### なぜ新規 RED テストの heredoc は OK か
+
+テスト弱体化（既存の PASS テストを失敗しないように書き換える等）の防止が目的であり、新規 RED テスト作成は TDD の正規手順であって弱体化ではない。
+**既存テストの改変・設定ファイルの変更には heredoc を使わない**。
+
+---
+
+## パターン集
+
+### パターン 1: 新しいビジネスロジック
+
+```python
+# ① RED: 先にテストを書く
+# tests/backend/unit/test_fee_service.py
+def test_calculate_subscription_fee_with_discount():
+    """割引適用後の月額計算"""
+    from app.modules.billing.services.fee_service import calculate_subscription_fee
+    result = calculate_subscription_fee(base_amount=10000, discount_rate=0.1)
+    assert result == 9000
+
+# PYTHONPATH=apps/backend pytest tests/backend/unit/test_fee_service.py -v
+# → FAILED: ImportError または AssertionError
+
+# ② 実装
+def calculate_subscription_fee(base_amount: int, discount_rate: float) -> int:
+    return int(base_amount * (1 - discount_rate))
+
+# ③ GREEN
+# PYTHONPATH=apps/backend pytest tests/backend/unit/test_fee_service.py -v
+# → PASSED
+```
+
+### パターン 2: バグ修正（再現テスト先行）
+
+```python
+# ① RED: バグを再現するテストを書く
+def test_invoice_total_includes_tax():
+    """バグ: 消費税が合計に含まれていない"""
+    invoice = Invoice(subtotal=1000, tax_rate=0.1)
+    assert invoice.total == 1100  # 現在は 1000 を返す
+
+# → FAILED: AssertionError: assert 1000 == 1100
+
+# ② 修正
+@property
+def total(self) -> int:
+    return int(self.subtotal * (1 + self.tax_rate))
+
+# ③ GREEN: PASSED
+```
+
+### パターン 3: 状態遷移テスト
+
+```python
+# ① RED: 遷移ルールを先に定義する
+def test_contract_cannot_activate_from_cancelled():
+    """解約済み契約を有効化しようとするとエラー"""
+    contract = Contract(status=ContractStatus.CANCELLED)
+    with pytest.raises(InvalidStateTransitionError):
+        contract.activate()
+
+def test_contract_can_activate_from_pending():
+    """保留中の契約は有効化できる"""
+    contract = Contract(status=ContractStatus.PENDING)
+    contract.activate()
+    assert contract.status == ContractStatus.ACTIVE
+
+# ② 実装（状態遷移ルールを service に書く）
+# ③ GREEN
+```
+
+### パターン 4: API エンドポイント（integration テスト）
+
+```python
+# ① RED: エンドポイントの仕様を先に書く
+# tests/backend/integration/test_invoice_api.py
+async def test_create_invoice_returns_201(client, sample_store):
+    """POST /api/billing/invoices は 201 を返す"""
+    payload = {"store_id": str(sample_store.store_id), "amount": 1000}
+    response = await client.post("/api/billing/invoices", json=payload)
+    assert response.status_code == 201
+    assert "invoice_id" in response.json()
+
+# PYTHONPATH=apps/backend pytest tests/backend/integration/test_invoice_api.py -v
+# → FAILED (404 or error)
+
+# ② 実装（route, service, repository を追加）
+# ③ GREEN
+```
+
+### パターン 5: parametrize で複数ケース
+
+```python
+import pytest
+
+@pytest.mark.parametrize("amount,rate,expected", [
+    (1000, 0.1, 100),
+    (5000, 0.05, 250),
+    (0, 0.1, 0),
+])
+def test_calculate_fee_parametrized(amount, rate, expected):
+    assert calculate_fee(amount, rate) == expected
+```
+
+---
+
+## Vitest（Frontend）
+
+### テスト配置
+
+```
+tests/frontend/
+├── unit/
+│   └── xxx.test.ts(x)
+└── e2e/
+    └── xxx.spec.ts
+```
+
+`apps/frontend/package.json` の `test:unit` script は `vitest run ../../tests/frontend/unit` を実行する（Makefile `test-frontend` ターゲットから呼び出される）。
+
+### コマンド
+
+| 用途 | コマンド |
+|------|---------|
+| 全テスト実行 | `make test-frontend` |
+| 全テスト実行（npm 直接） | `cd apps/frontend && npm run test:unit` |
+| 特定ファイル | `cd apps/frontend && npx vitest run ../../tests/frontend/unit/xxx.test.ts` |
+| ウォッチモード（開発中） | `cd apps/frontend && npx vitest` |
+
+### import 方針
+
+`globals: true` は使用しない前提とし、各テストファイルで vitest を明示 import する:
+
+```typescript
+import { describe, it, expect, beforeEach } from "vitest"
+```
+
+理由: `tsc --noEmit` との衝突を回避。
+
+### RED-GREEN サイクル例（Zod スキーマ変更）
+
+```typescript
+// ① RED: 新しいバリデーションルールのテストを先に書く
+// tests/frontend/unit/createApplicationSchema.test.ts
+import { describe, it, expect } from "vitest"
+import { createApplicationSchema } from "@/lib/validations/application"
+
+describe("createApplicationSchema", () => {
+  it("rejects phone without country code", () => {
+    const schema = createApplicationSchema()
+    const result = schema.safeParse({
+      // ... required fields ...
+      phone: "+8109012345678",  // ← 新ルール: 国番号不可
+    })
+    expect(result.success).toBe(false)  // ← まだ FAIL する
+  })
+})
+
+// make test-frontend → FAILED
+
+// ② 実装: PHONE_REGEX を更新
+// ③ GREEN: make test-frontend → PASSED
+```
+
+### Zustand store テストパターン
+
+```typescript
+import { describe, it, expect, beforeEach } from "vitest"
+import { useXxxStore } from "@/store/xxxStore"
+
+describe("useXxxStore", () => {
+  beforeEach(() => {
+    useXxxStore.setState({ /* initial state */ })
+  })
+
+  it("action updates state correctly", () => {
+    useXxxStore.getState().someAction("value")
+    expect(useXxxStore.getState().someField).toBe("value")
+  })
+})
+```
+
+### よくある失敗パターン（Vitest）
+
+| 症状 | 原因 | 対処 |
+|------|------|------|
+| `No test files found` | `include` パターンと不一致 | `tests/frontend/unit/**/*.test.ts(x)` に配置する |
+| `Cannot find module '@/...'` | path alias が解決できない | `vitest.config.ts` の path alias 設定を確認 |
+| 型エラー（`describe` is not defined） | `globals: true` 不使用のため | `import { describe, it, expect } from "vitest"` を追加 |
+
+---
+
+## 証跡記録
+
+`/develop` Phase 5 の実装サマリー（`.claude/templates/implementation-summary-comment.md`）に以下を記録する。
+
+```markdown
+### TDD 証跡
+| 項目 | 内容 |
+|------|------|
+| TDD 判定 | 必須 / スキップ（理由: ）|
+| 追加したテスト | `tests/backend/unit/test_xxx.py::test_function_name` |
+| RED コマンド | `PYTHONPATH=apps/backend pytest tests/backend/unit/test_xxx.py -v` |
+| RED 結果 | FAILED: 1 failed, 0 passed（AssertionError: ...）|
+| GREEN コマンド | `PYTHONPATH=apps/backend pytest tests/backend/unit/test_xxx.py -v` |
+| GREEN 結果 | PASSED: 1 passed |
+```
+
+**スキップの場合:**
+
+```markdown
+### TDD 証跡
+| 項目 | 内容 |
+|------|------|
+| TDD 判定 | スキップ（理由: .claude/ ファイルのみの変更。コード変更なし）|
+| 追加したテスト | なし |
+| RED コマンド | なし |
+| GREEN コマンド | なし |
+```
+
+---
+
+## よくある失敗パターン
+
+| 症状 | 原因 | 対処 |
+|------|------|------|
+| `0 selected` | path 指定ミス（存在しない glob / 誤った filename） | `tests/backend/unit/test_xxx.py` を絶対 / 相対パスで正確に指定 |
+| `all skipped` | `@pytest.mark.skip` / `xfail` が残っている | skip マーカーを確認して削除 |
+| `ImportError` in RED | 実装前にテストを書いたため | 正常な RED（次のステップで実装する） |
+| RED で PASS になる | テストが正しい振る舞いを定義できていない | テストの期待値を確認する |
+| GREEN にならない | 実装が不足している | エラーメッセージを読んで追加実装する |
+
+---
+
+## 棲み分け: testing-patterns / verification-before-completion との違い
+
+| スキル | 担当範囲 |
+|--------|---------|
+| **tdd-workflow**（本スキル） | RED-GREEN フロー、TDD パターン集、証跡フォーマット |
+| **testing-patterns** | DB フィクスチャ設計、CI 共有 DB 問題回避、テストファイル構成 |
+| **verification-before-completion** | 完了主張前の 5 ステップゲート（IDENTIFY / RUN / READ / VERIFY / CLAIM） |
+| **test-design** | Critical Path 判定・保護レイヤー選択・Coverage expectation |
+| **rules/tdd-gate.md** | TDD 必須 / スキップ判定の SSOT |
+
+統合テストで DB が必要な場合は `testing-patterns` も参照する。
+
+---
+
+## 証跡チェーン
+
+TDD 証跡は以下の順で引き継がれる。切れた場合は `/pr` でブロックされる。
+
+```
+/plan 検証定義
+  └─ TDD 判定 + 想定 RED/GREEN コマンド
+
+/tdd RED 証跡（Issue コメント ← gh issue comment で投稿）
+  └─ TDD 判定 + 追加テスト + RED コマンド + RED 結果
+
+/develop 実装サマリー（implementation-summary-comment.md）
+  └─ TDD 証跡テーブル（追加テスト / RED / GREEN）
+
+/verify 検証結果コメント（verification-result-comment.md）
+  └─ TDD 証跡テーブル（/develop から転記 + 再確認結果）
+
+/pr PR ゲート
+  └─ TDD 証跡の有無を確認（ブラウザ確認と同等のゲート）
+```
+
+> **重要**: `/tdd` の RED 証跡は **必ず Issue コメントに投稿**する。会話内のテキスト出力だけではセッション間で失われ、`/develop` が証跡を確認できなくなる。
+
+---
+
+## 関連ファイル
+
+### プロジェクト内参照
+
+- [rules/tdd-gate.md](../../rules/tdd-gate.md) - TDD 判断基準（必須/スキップ + Critical Path 連携）
+- [skills/test-design/SKILL.md](../test-design/SKILL.md) - Critical Path 判定・保護レイヤー
+- [skills/verification-before-completion/SKILL.md](../verification-before-completion/SKILL.md) - 完了主張前のゲート
+- [skills/testing-patterns/SKILL.md](../testing-patterns/SKILL.md) - DB フィクスチャ
+- [apps/backend/pytest.ini](../../../apps/backend/pytest.ini) - pytest 設定（marker は `tc_id` のみ）
+- [templates/implementation-summary-comment.md](../../templates/implementation-summary-comment.md) - TDD 証跡テーブル
+
+### 公式ドキュメント・外部リファレンス
+
+- [pytest 公式ドキュメント](https://docs.pytest.org/)
+- [pytest-asyncio ドキュメント](https://pytest-asyncio.readthedocs.io/)
+- [pytest parametrize](https://docs.pytest.org/en/latest/how-to/parametrize.html)
+- [Vitest 公式](https://vitest.dev/)

--- a/.claude/skills/test-design/SKILL.md
+++ b/.claude/skills/test-design/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: test-design
+description: |
+  テスト設計スキル。Critical Path 判定・保護レイヤー選択・Coverage expectation の判断基準を提供。
+  `/plan` Phase 1.3（Critical Path 判定）で Critical または Mixed と判定された Issue で追加読込される。
+---
+
+# テスト設計スキル
+
+## 概要
+
+`/plan` の成果物として test design を decision-complete にするためのスキル。
+高リスク Issue で「何を守るか」「どの層で守るか」「どこまで守るか」を迷わず決められる判断基準を提供する。
+
+> **本リポジトリの pytest marker は `tc_id` のみ**（`apps/backend/pytest.ini` 参照）。SubsCore 由来の `unit` / `integration` / `integration_local` marker は本リポジトリでは適用しない。テスト種別はディレクトリ配置（`tests/backend/{unit,integration}/`、`tests/frontend/{unit,e2e}/`）で分類する。
+
+## 非ゴール（このスキルが扱わないもの）
+
+| 扱わない内容 | 担当スキル |
+|-------------|-----------|
+| fixture / DB 共有ルール | [testing-patterns](../testing-patterns/SKILL.md) |
+| RED-GREEN 実行手順・証跡記録 | [tdd-workflow](../tdd-workflow/SKILL.md) |
+| TDD 必須 / スキップ判定の SSOT | [rules/tdd-gate.md](../../rules/tdd-gate.md) |
+| 完了主張前の検証ゲート | [verification-before-completion](../verification-before-completion/SKILL.md) |
+
+---
+
+## 使い方
+
+### いつ読み込むか
+
+`/plan` Phase 1.2（依存先トレース）完了後に Critical Path 判定を行い、**Critical または Mixed** と判定された場合にこのスキルを追加読込する。
+
+Non-critical の場合はこのスキルは不要。既存の Critical Path テーブルを埋めるだけで十分。
+
+### 読み込みフロー
+
+```
+/plan Phase 1.2 完了
+  ↓
+Critical Path 判定（下記の判定基準で評価）
+  ↓
+Critical or Mixed → このスキルを読み込む
+Non-critical     → スキップ（既存テーブルを埋めるだけ）
+```
+
+---
+
+## 詳細
+
+### 1. Critical Path 判定基準
+
+Issue の変更対象を以下の基準で判定する。
+
+#### Critical（全テスト層で保護が必要）
+
+以下の **いずれか** に該当する場合は Critical:
+
+| 領域 | 例 |
+|------|-----|
+| 申込導線（フォーム → 確認 → 決済 → 完了） | 申込フォーム、カード登録、決済処理 |
+| auth / 権限（JWT 検証、ロールチェック） | ログイン、トークンリフレッシュ、権限ガード |
+| billing / payment / 契約の状態遷移 | 契約作成、請求書発行、決済フロー |
+| callback を含む整合性境界 | 外部決済結果通知、Webhook、OAuth callback |
+| 外部連携の冪等性・排他制御 | 二重課金防止、外部 API リトライ |
+
+#### Non-critical（標準テストで十分）
+
+以下の **すべて** に該当する場合は Non-critical:
+
+- 状態遷移を含まない
+- 外部連携・callback がない
+- auth / 権限に影響しない
+- 申込導線に影響しない
+
+例: UI 文言修正、CSS 調整、管理画面の表示改善、DX ツーリング
+
+#### Mixed（Critical + Non-critical が混在）
+
+Issue に Critical と Non-critical の両方が含まれる場合。
+Critical 部分は Critical の保護レイヤー、Non-critical 部分は標準テストで保護する。
+
+### 2. 保護レイヤー選択ガイド
+
+判定結果に応じて、どのテスト層で保護するかを選択する。
+
+| レイヤー | 何を保護するか | いつ使うか | コマンド例 |
+|---------|--------------|-----------|-----------|
+| **Unit** | ドメインロジック、計算、バリデーション | ビジネスルール・状態遷移のロジックテスト | `make test-backend`（全実行）/ focused: `PYTHONPATH=apps/backend pytest tests/backend/unit/test_xxx.py -v` |
+| **Integration** | DB / API / 外部連携の結合 | Repository、API エンドポイント、ミドルウェア | `make test-backend`（全実行）/ focused: `PYTHONPATH=apps/backend pytest tests/backend/integration/test_xxx.py -v` |
+| **Browser evidence** | 実画面の表示・操作・Console / Network | UI 導線、レスポンシブ、エラー表示 | `/verify` 軽量ヘルスチェック（ローカル、pre-merge） |
+| **Manual** | 自動化困難な確認 | 外部リダイレクト、サンドボックス決済、印刷 | 手動実行 + 証跡スクリーンショット |
+
+#### Critical Path での推奨組み合わせ
+
+| Critical 領域 | Unit | Integration | Browser | Manual |
+|:-------------|:----:|:-----------:|:-------:|:------:|
+| 申込導線 | o | o | o | - |
+| auth / 権限 | o | o | - | - |
+| billing 状態遷移 | o | o | - | - |
+| callback 整合性 | o | o | - | o |
+| 外部連携冪等性 | o | o | - | o |
+
+`o` = 必須、`-` = 不要
+
+### 3. Coverage expectation ルール
+
+| 判定 | Coverage expectation |
+|------|---------------------|
+| **Critical** | Critical scope = 100%（全パス・全境界をテストで保護） |
+| **Non-critical** | Touched scope = 90%（変更した範囲の主要パスを保護） |
+| **Mixed** | Critical 部分 = 100% + Touched non-critical = 90% |
+| **N/A** | DX / `.claude/` のみの変更、Pencil 調整のみ、文言修正のみ |
+
+#### Touched scope の定義
+
+「Touched scope」とは、この Issue で **新規作成または変更したコード** のうち、テスト可能な部分を指す。
+
+含まれるもの:
+- 新規作成した関数・メソッド・クラス
+- 変更したビジネスロジック
+- 追加・変更した API エンドポイント
+- 変更した DB クエリ・リポジトリメソッド
+
+含まれないもの:
+- import 文の追加・変更
+- 型定義のみの変更
+- 設定ファイル（`.env`, `config.py` 等）
+- テンプレート・静的ファイル
+
+#### N/A 条件
+
+N/A は独立した分類ではなく、**テスト可能な実行コードが存在しない場合に Non-critical に対して使う例外**。Critical / Mixed の Issue では N/A を選択できない。
+
+以下の **いずれか** に該当する場合、Coverage expectation は N/A:
+
+- `.claude/` / `docs/` / `.github/` のみの変更（テスト可能な実行コードがない）
+- Pencil 調整のみの変更（デザイン変更のみ、ロジック変更なし）
+- UI の文言・CSS のみの変更（表示テキストやスタイルのみ、ロジック変更なし）
+
+> **注意**: `scripts/` 配下の Python スクリプト等、テスト可能な実行コードを含む変更は N/A ではなく Non-critical（90%）を選択すること。
+
+### 4. Focused test commands テンプレート
+
+`/plan` の検証定義に記載する focused test commands の例:
+
+```bash
+# Critical: billing 状態遷移
+PYTHONPATH=apps/backend pytest tests/backend/unit/test_invoice_service.py -v
+PYTHONPATH=apps/backend pytest tests/backend/integration/test_invoice_api.py -v
+
+# Critical: auth
+PYTHONPATH=apps/backend pytest tests/backend/unit/test_auth.py -v
+
+# Non-critical: touched scope（変更したファイルに紐づく test を focused で）
+PYTHONPATH=apps/backend pytest tests/backend/unit/test_<changed_file>.py -v
+
+# Frontend
+cd apps/frontend && npx vitest run ../../tests/frontend/unit/<changed_module>.test.ts
+```
+
+### 5. フロントエンドの保護レイヤー分担
+
+フロントエンドの品質は以下の 3 層で保護する。E2E（Playwright）の CI 回帰自動化は本リポジトリでは現時点では未採用。
+
+| レイヤー | 担当 | 検知対象 |
+|---------|------|---------|
+| **CI build** | `make test-frontend`（`npm run lint:biome` + `check:segments` + `test:unit`） | compile エラー、型エラー、Vitest unit テスト |
+| **Browser evidence** | `/verify` 軽量ヘルスチェック（ローカル） | runtime エラー、Console / Network、UI 表示、状態遷移 |
+| **Backend integration** | `make test-backend` の integration テスト | API 正当性、DB 整合性、callback 処理 |
+
+> **将来の再検討**: 申込導線の大規模改修や、build では検知できない回帰が頻発した場合に E2E（Playwright）導入を再検討する。
+
+---
+
+## `/plan` での出力形式
+
+このスキルを読み込んだ場合、`/plan` の検証定義（`.claude/templates/issue-implementation-plan.md` の Critical Path セクション）に以下を必ず含める:
+
+```markdown
+### Critical Path / Coverage expectation
+
+| 項目 | 内容 |
+|------|------|
+| Critical Path 判定 | Critical / Non-critical / Mixed |
+| Critical scope | [Critical と判定した領域を列挙] |
+| 保護レイヤー | Unit / Integration / Browser evidence / Manual |
+| Coverage expectation | Critical = 100% / Touched non-critical = 90% / N/A |
+| Focused test commands | [具体的なコマンドを列挙] |
+```
+
+---
+
+## 関連ファイル
+
+- [testing-patterns/SKILL.md](../testing-patterns/SKILL.md) - fixture / DB 共有ルール
+- [tdd-workflow/SKILL.md](../tdd-workflow/SKILL.md) - RED-GREEN 実行手順
+- [verification-before-completion/SKILL.md](../verification-before-completion/SKILL.md) - 完了主張前のゲート
+- [rules/tdd-gate.md](../../rules/tdd-gate.md) - TDD 必須 / スキップ判定 SSOT
+- [templates/issue-implementation-plan.md](../../templates/issue-implementation-plan.md) - 検証定義テンプレート

--- a/.claude/skills/verification-before-completion/SKILL.md
+++ b/.claude/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: verification-before-completion
+description: |
+  完了主張前の検証ゲートスキル。
+  作業完了・テストパス・ビルド成功を主張する前に、検証コマンドの実行と出力確認を義務付ける。
+  `/develop` Phase 3 / `/verify` / `/pr` から参照される。
+---
+
+# Verification Before Completion
+
+## 概要
+
+**検証なき完了主張は、効率ではなく不誠実。**
+
+このスキルは「どう証明するか」を定義する。
+「いつ止まるか」は [`completion-quality` rule](../../rules/completion-quality.md) が担当する。
+
+| 担当 | 定義 |
+|------|------|
+| `completion-quality` rule | **いつ止まるか**（3 基準: 取り消せない・繰り返し使われる・印象に残る） |
+| **本スキル** | **どう証明するか**（5 ステップゲート） |
+
+---
+
+## 使い方
+
+以下の場面で本スキルが適用される:
+
+- `/develop` Phase 3（品質チェック）で検証コマンドを実行するとき
+- `/verify` で証跡を確認するとき
+- `/pr` で完了ゲートを通すとき
+- コミット・プッシュ前に状態を主張するとき
+- エージェントチームのメンバーが完了報告するとき
+
+---
+
+## 5 ステップゲート
+
+```
+完了を主張する前に、必ずこの順序で実行する:
+
+1. IDENTIFY: この主張を証明するコマンドは何か？
+2. RUN:      コマンドを完全実行する（新鮮な実行、部分実行は不可）
+3. READ:     出力全体を読み、exit code・失敗数・警告を確認する
+4. VERIFY:   出力が主張を裏付けているか？
+   - NO  → 実際の状態を証拠付きで報告する
+   - YES → 証拠付きで主張する
+5. CLAIM:    証拠が揃ってはじめて完了を主張する
+
+どのステップも省略 = 検証していない
+```
+
+---
+
+## docdd-starters の proof commands
+
+| 主張 | 必要なコマンド | 不十分な代替 |
+|------|--------------|-------------|
+| Backend テストがパスする | `make test-backend` の出力: 0 failures | 前回の実行結果、「たぶん通る」 |
+| Frontend テストがパスする | `make test-frontend` の出力: 0 failures（`lint:biome` + `check:segments` + `test:unit` まで PASS） | unit だけ通った |
+| 全テストがパスする | `make test` の出力: 0 failures | 片方だけ通った |
+| `.claude/` の変更が壊れていない | `make validate-claude` の出力: exit 0 | リンクが解決しているように見えた |
+| DocDD が整合している | `make traceability` の出力: exit 0 | frontmatter だけ見た |
+| バグが修正された | 元の症状を再現するテストが PASS | コード変更した、たぶん直った |
+| 回帰テストが有効 | RED-GREEN サイクル検証済み（[`tdd-workflow`](../tdd-workflow/SKILL.md) 参照） | テストが 1 回パスした |
+| エージェントが完了した | VCS diff で変更を確認 | エージェントの「成功」報告 |
+| 要件を満たしている | 受け入れ条件の 1 行ずつチェック | テストがパスしたから完了 |
+
+> 補足: `make quality-gate` などの統合ターゲットは本リポジトリには **存在しない**（後続 Issue 5-1 想定）。上記 4 ターゲット（`test-backend` / `test-frontend` / `validate-claude` / `traceability`）の **組み合わせ** で品質を主張する。
+
+---
+
+## 禁止パターン
+
+### 検証前に使ってはいけない表現
+
+- "should"（たぶん通る）
+- "probably"（おそらく大丈夫）
+- "seems to"（〜のように見える）
+- "Great!" / "Perfect!" / "Done!"（検証前の満足表現）
+
+### 合理化への対処
+
+| 言い訳 | 現実 |
+|--------|------|
+| 「たぶん動く」 | 検証コマンドを実行せよ |
+| 「自信がある」 | 自信 ≠ 証拠 |
+| 「今回だけ」 | 例外なし |
+| 「lint は通った」 | lint ≠ テスト ≠ ビルド |
+| 「エージェントが成功と言った」 | 独立して検証せよ |
+| 「部分チェックで十分」 | 部分は何も証明しない |
+
+---
+
+## 検証パターン
+
+### テスト
+
+```
+# 正しい
+make test-backend → 出力を確認 → 「N passed, 0 failed」→ 完了主張
+# 間違い
+「コード的に正しいはず」→ 完了主張
+```
+
+### RED-GREEN（TDD）
+
+```
+# 正しい
+テスト作成 → 実行（FAIL 確認）→ 実装 → 実行（PASS 確認）→ 完了主張
+# 間違い
+「回帰テストを書いた」（RED-GREEN 未検証）→ 完了主張
+```
+
+### `.claude/` の整合性
+
+```
+# 正しい
+make validate-claude → exit 0 確認 → 完了主張
+# 間違い
+「frontmatter だけ目視した」→ 完了主張（リンク到達性は？）
+```
+
+### 要件チェック
+
+```
+# 正しい
+計画を再読 → チェックリスト作成 → 各項目を検証 → ギャップ or 完了を報告
+# 間違い
+「テストが通ったからフェーズ完了」
+```
+
+### エージェント委譲
+
+```
+# 正しい
+エージェント完了報告 → VCS diff 確認 → 変更内容を検証 → 実際の状態を報告
+# 間違い
+エージェントの報告を信頼する
+```
+
+---
+
+## 失敗扱いになる出力
+
+以下は「パス」として扱わない:
+
+- `0 selected`
+- `all skipped`
+- `script not found`
+- `make test-backend` / `make test-frontend` / `make test` / `make validate-claude` / `make traceability` が FAIL
+- 実行コマンド未記録
+
+正しいコマンドを再実行するか、なぜ実行できないかを明記すること。
+
+---
+
+## 適用タイミング
+
+**必ず適用する場面:**
+- 完了・成功・パスを主張するあらゆる表現の前
+- コミット・PR 作成・タスク完了の前
+- 次のタスクへ移る前
+- エージェントに委譲した後
+
+---
+
+## 関連ファイル
+
+### プロジェクト内参照
+
+- [rules/completion-quality.md](../../rules/completion-quality.md) - いつ止まるか（棲み分け対象）
+- [skills/tdd-workflow/SKILL.md](../tdd-workflow/SKILL.md) - TDD 証跡チェーン・RED-GREEN サイクル
+- [skills/test-design/SKILL.md](../test-design/SKILL.md) - Critical Path 判定・Coverage expectation
+- [rules/tdd-gate.md](../../rules/tdd-gate.md) - TDD 判断基準（必須 / スキップ）
+
+### 外部リファレンス
+
+- [Superpowers: verification-before-completion](https://github.com/obra/superpowers/tree/main/skills/verification-before-completion) - 原典

--- a/.claude/templates/implementation-summary-comment.md
+++ b/.claude/templates/implementation-summary-comment.md
@@ -43,8 +43,8 @@
 | 項目 | 内容 |
 |------|------|
 | TDD 判定 | 必須 / スキップ（理由: ）|
-| 追加したテスト | Backend: `apps/backend/tests/.../test_xxx.py::test_name` / Frontend: `apps/frontend/src/.../__tests__/xxx.test.ts`（スキップの場合は「なし」）|
-| RED コマンド | `make test-backend` / `make test-frontend` 等（スキップの場合は「なし」）|
+| 追加したテスト | Backend: `tests/backend/<unit\|integration>/test_xxx.py::test_name` / Frontend: `tests/frontend/unit/xxx.test.ts`（スキップの場合は「なし」）|
+| RED コマンド | `make test-backend` / `make test-frontend` または focused: `PYTHONPATH=apps/backend pytest tests/backend/.../test_xxx.py::test_name -v` / `cd apps/frontend && npx vitest run ../../tests/frontend/unit/xxx.test.ts`（スキップの場合は「なし」）|
 | RED 結果 | FAILED: X failed（AssertionError / ImportError 等）/ なし（スキップ）|
 | GREEN コマンド | `make test-backend` / `make test-frontend` 等（スキップの場合は「なし」）|
 | GREEN 結果 | PASSED: X passed / なし（スキップ）|
@@ -52,7 +52,7 @@
 ### Coverage 証跡
 | 項目 | 内容 |
 |------|------|
-| Critical Path 判定 | /plan の検証定義から転記（Critical / Non-critical / Mixed / N/A） |
+| Critical Path 判定 | /plan の検証定義から転記（Critical / Non-critical / Mixed。N/A は Critical Path 判定では選択不可、Coverage expectation の例外として Non-critical に対してのみ使用） |
 | 保護レイヤー | /plan の検証定義から転記 |
 | Coverage expectation | /plan の検証定義から転記 |
 | Focused test commands | /plan の検証定義から転記 |

--- a/.claude/templates/issue-implementation-plan.md
+++ b/.claude/templates/issue-implementation-plan.md
@@ -146,24 +146,31 @@
 | 想定 RED コマンド | `make test-backend` / `make test-frontend` または focused pytest / vitest コマンド（スキップ時は「該当なし」） |
 | 想定 GREEN コマンド | `make test-backend` / `make test-frontend` または focused pytest / vitest コマンド（スキップ時は「該当なし」） |
 
-> **判断基準**: 「外部連携・状態遷移・認証・API 契約変更を含むなら必須、それ以外は任意」の経験則で判定する（SSOT 化の予定はテンプレ末尾の forward reference を参照）。
+> **判断基準 SSOT**: [`.claude/rules/tdd-gate.md`](../rules/tdd-gate.md)（必須領域・スキップ条件・Critical Path 連携）。RED-GREEN サイクル・パターン集・証跡フォーマットは [`.claude/skills/tdd-workflow/SKILL.md`](../skills/tdd-workflow/SKILL.md) を参照。
 
 ### Critical Path / Coverage expectation
 
-<!-- 判定基準（簡易リファレンス）:
-  Critical: 状態遷移・外部連携・callback・認証・申込導線を含む
-  Non-critical: 上記に該当しない（UI文言、CSS、DX等）
-  Mixed: Critical + Non-critical が混在
-  N/A 条件: .claude/ / docs/ のみの変更、デザイン調整のみ、文言修正のみ
+<!-- 判定基準・保護レイヤー選択・Coverage expectation の SSOT は .claude/skills/test-design/SKILL.md。
+  Critical / Mixed と判定した場合は同 skill を Read してから保護レイヤーと Focused test commands を埋める。
+  簡易リファレンス:
+    Critical Path 判定（3 値）:
+      Critical: 状態遷移・外部連携・callback・認証・申込導線を含む
+      Non-critical: 上記に該当しない（UI文言、CSS、DX等）
+      Mixed: Critical + Non-critical が混在
+    Coverage expectation の N/A 条件（Non-critical で実行コードを含まない場合の例外）:
+      .claude/ / docs/ のみの変更、デザイン調整のみ、文言修正のみ
+      → Critical / Mixed では N/A を選択不可
 -->
 
 | 項目 | 内容 |
 |------|------|
-| Critical Path 判定 | Critical / Non-critical / Mixed / N/A |
+| Critical Path 判定 | Critical / Non-critical / Mixed |
 | Critical scope | Critical と判定した領域を列挙（Non-critical の場合は「なし」） |
 | 保護レイヤー | Unit / Integration / Browser evidence / Manual |
-| Coverage expectation | Critical = 100% / Non-critical touched scope = 90% / Mixed = critical 100% + touched non-critical 90% / N/A |
+| Coverage expectation | Critical = 100% / Non-critical touched scope = 90% / Mixed = critical 100% + touched non-critical 90% / N/A（Non-critical で実行コードなしの場合のみ） |
 | Focused test commands | /plan の計画から転記 |
+
+> **判定 SSOT**: [`.claude/skills/test-design/SKILL.md`](../skills/test-design/SKILL.md)（保護レイヤー選択 / Coverage expectation の詳細表）
 
 ### Issue 固有の検証定義
 
@@ -220,8 +227,5 @@
 
 | 参照先（未存在） | 用途 | 予定 Issue |
 |--------------|------|----------|
-| `.claude/rules/tdd-gate.md` | TDD 判定の SSOT | 後続 Issue（4-2 想定） |
-| `.claude/skills/test-design/SKILL.md` | Critical Path 判定スキル | 後続 Issue（4-2 想定） |
 | `scripts/claude/verify-issue.sh`, `scripts/claude/quality-gate.sh` | Issue 単位の品質ゲート自動化 | 後続 Issue（5-1 / D-1 想定） |
 | `.claude/rules/multi-model-review.md` | 3 reviewer 並列レビュー | 後続 Issue（D-1 想定） |
-| `.claude/references/applicable-skills.md` | 適用スキル一覧の SSOT | 後続 Issue（4-1 想定） |


### PR DESCRIPTION
## 変更内容

- Wave 4-2: TDD / verification 系の cross-cutting skill 3 つ（`tdd-workflow` / `test-design` / `verification-before-completion`）を `.claude/skills/` に新設し、TDD 必須 / スキップ判定の SSOT を `.claude/rules/tdd-gate.md` として独立。
- `/develop` `/verify` `/tdd` `/plan` `/pr` の TDD・検証関連の説明実体を skill / rule へのポインタ化（重複定義の解消）。5 コマンドの末尾 forward reference 表から該当 4 シンボル（`tdd-workflow` / `test-design` / `verification-before-completion` / `tdd-gate.md`）を削除。
- `.claude/references/applicable-skills.md` と `.claude/skills/README.md` の Cross-Cutting Skills 表に 3 skill を同期。`.claude/templates/issue-implementation-plan.md` の Critical Path / TDD 判定セクションから `tdd-gate.md` / `test-design` への参照を追加し、forward reference 表から削除。
- `.claude/commands/develop.md` の focused pytest 例を `apps/backend/tests/...` → `tests/backend/...`（実配置 + `PYTHONPATH=apps/backend` 整合）に修正。`.claude/templates/implementation-summary-comment.md` の TDD 証跡パスと Critical Path 判定値（`Critical / Non-critical / Mixed` の 3 値、N/A は Coverage expectation の例外）も新 SSOT に揃えた。
- レイヤー: DX / `.claude/` のみ。実行コードへの変更なし。

## テスト

- [x] `make validate-claude` PASS（20 passed / 0 failed / 既存 warning のみ）
- [x] 内部リンク整合性チェック PASS（新規 4 ファイル 29 link / 修正 8 ファイル 82 link → MISS 0）
- [x] V3〜V9 自動検査 PASS（trailer / forward reference / frontmatter / dogfooding all PASS）
- [ ] `make test-backend` / `make test-frontend` — N/A（dx-docs 変更のみ、実行コードを含まない）
- [ ] `make traceability` — N/A（DocDD 7 軸の文書変更なし）
- [ ] `/verify` ブラウザヘルスチェック — N/A（フロントエンド変更なし）

## 残留リスク（次 Issue で対応）

- `.claude/CLAUDE.md` の Cross-Cutting Skills 表 / ルール表に新規 3 skill / `tdd-gate` が未記載（`/review` P2 / 非対応）。本 Issue のスコープ外として次の小さな docs Issue で同期予定。
- `.claude/skills/test-design/SKILL.md` の Coverage expectation 表で N/A 表記が並列して見える誤読リスク（P3 / 非対応）。test-design 刷新時に対応。

## 関連

Closes #54
