### PR TITLE
feat(scripts): add verify-issue-detect.sh + bats fixture (#61)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: tf-init tf-plan tf-apply tf-destroy tf-output
 .PHONY: deploy-backend-stg deploy-frontend-stg deploy-stg deploy-backend-prod deploy-frontend-prod deploy-prod
 .PHONY: ecs-status ecs-logs-backend ecs-logs-frontend ecs-sh
-.PHONY: shell-lint shell-format-check test-hooks
+.PHONY: shell-lint shell-format-check test-hooks verify-issue-detect
 .PHONY: validate-claude
 
 PYTHON ?= python3
@@ -60,6 +60,7 @@ SHELL_FILES := .claude/hooks/block-dangerous.sh \
 	scripts/bootstrap.sh \
 	scripts/claude/detect-capabilities.sh \
 	scripts/claude/validate-claude-config.sh \
+	scripts/claude/verify-issue-detect.sh \
 	scripts/deploy/terraform.sh \
 	scripts/deploy/build-and-deploy.sh \
 	scripts/github/bootstrap-labels.sh
@@ -83,6 +84,16 @@ test-hooks:
 		bats scripts/claude/test-hooks.bats; \
 	else \
 		echo "WARN: bats not found, skipping test-hooks"; \
+	fi
+
+verify-issue-detect:
+	@if command -v bats >/dev/null 2>&1; then \
+		bats scripts/claude/test/verify-issue-detect.bats; \
+	elif [ "$$CI" = "true" ] || [ "$$VERIFY_DETECT_REQUIRE_BATS" = "1" ]; then \
+		echo "ERROR: bats not found (required when CI=true or VERIFY_DETECT_REQUIRE_BATS=1)"; \
+		exit 1; \
+	else \
+		echo "WARN: bats not found, skipping verify-issue-detect"; \
 	fi
 
 # ─── Terraform ───────────────────────────────────────────

--- a/scripts/claude/README.md
+++ b/scripts/claude/README.md
@@ -75,6 +75,11 @@ VERIFY_BASE_REF=origin/main scripts/claude/verify-issue-detect.sh --git
 
 CI shallow checkout / 別名 default branch / worktree 配下のいずれでも壊れないこと。
 
+> ⚠️ **`--git` のスコープ**: `merge-base..HEAD` の **コミット済み差分のみ** を対象とする。
+> staged / working-tree / untracked の未コミット変更は出ない。pre-commit ローカル
+> 検出には `--stdin` か `--files` を使う（`/verify` 標準フローでは `/develop`
+> でコミット済みのため `--git` で問題ない）。
+
 ### Make ターゲット
 
 | ターゲット | 動作 |
@@ -107,7 +112,7 @@ CI shallow checkout / 別名 default branch / worktree 配下のいずれでも�
 | `scripts/**`, `Makefile*`, `*.config.*`, `.claude/hooks/**`, `.claude/settings.json`, `.github/**`, `terraform/**` | `dx-config` | 動作確認 + 既存テスト非破壊 | 手動 |
 | `.claude/commands/**`, `.claude/rules/**`, `.claude/skills/**`, `.claude/templates/**`, `.claude/references/**` | `dx-docs` | `make validate-claude` + 目視確認 | `make validate-claude` |
 
-> **glob 表記はドキュメント用**。実装は anchored regex（例: `^apps/backend/app/modules/[^/]+/(domain|services)/`）で `verify-issue-detect.sh` 内に固定する。glob を `grep -E` に直渡しはしない。
+> **glob 表記はドキュメント用**。実装は anchored regex（例: `^apps/backend/app/modules/.+/(domain|services)/`）で `verify-issue-detect.sh` 内に固定する。`.+`（vs `[^/]+`）はネストしたモジュール（`modules/<a>/<b>/<layer>/...`）も拾うため。glob を `grep -E` に直渡しはしない。
 
 ---
 

--- a/scripts/claude/README.md
+++ b/scripts/claude/README.md
@@ -1,0 +1,119 @@
+# scripts/claude/
+
+Claude Code / DocDD ワークフローを支えるスクリプト群。
+
+> ⚠️ **証跡カテゴリ mapping table の SSOT は本 README ではない**。真の SSOT は
+> [`.claude/templates/issue-implementation-plan.md`](../../.claude/templates/issue-implementation-plan.md)
+> 「🗺️ 証跡マッピング表」。本 README は **派生表（human-readable）** として
+> 同表を転記したものであり、SSOT が更新されたら本 README と
+> `verify-issue-detect.sh` の anchored regex を同時に更新する。
+>
+> drift の自動検知は Phase F で `make validate-claude` 配下に追加予定（forward reference）。
+>
+> SSOT 階層:
+>
+> ```
+> 真の SSOT: .claude/templates/issue-implementation-plan.md「🗺️ 証跡マッピング表」
+>     ↓ 派生
+> 派生表 (human-readable):  scripts/claude/README.md（本ファイル）
+>     ↓ 実装
+> 実装 (executable):       scripts/claude/verify-issue-detect.sh の anchored regex
+>     ↓ 検証
+> 検証 (test):             scripts/claude/test/verify-issue-detect.bats fixture
+> ```
+
+---
+
+## スクリプト一覧
+
+| ファイル | 役割 | 呼び出し元 |
+|---------|------|-----------|
+| `detect-capabilities.sh` | gh / codex / pencil / aws 等の利用可否を JSON で出力 | `scripts/bootstrap.sh` |
+| `validate-claude-config.sh` | `.claude/` 配下の構成・命名・frontmatter を検証 | `make validate-claude` |
+| `validate_claude_frontmatter.py` | skill / command の frontmatter スキーマ検証 | `validate-claude-config.sh` 内部 |
+| `verify-issue-detect.sh` | 変更パスから必要証跡カテゴリを列挙する change-aware detector | `make verify-issue-detect`、5-2 / 5-3（後続 Issue） |
+| `test-hooks.bats` | `.claude/hooks/` の bats fixture | `make test-hooks` |
+| `test/verify-issue-detect.bats` | `verify-issue-detect.sh` の bats fixture | `make verify-issue-detect` |
+
+---
+
+## verify-issue-detect.sh
+
+変更パスを入力に、必要な証跡カテゴリを stdout に列挙する純粋関数。
+`/verify` と `make verify-issue`（5-2 で導入予定）の前段で使う。
+
+### 使い方
+
+```bash
+# 1) stdin（改行区切り）
+echo "apps/backend/app/modules/example/domain/foo.py" \
+  | scripts/claude/verify-issue-detect.sh --stdin
+
+# 2) 引数
+scripts/claude/verify-issue-detect.sh --files \
+  apps/backend/app/modules/example/domain/foo.py \
+  docs/7-axis/3_DM/DM-User.md
+
+# 3) git merge-base diff（default は main、VERIFY_BASE_REF で上書き可）
+scripts/claude/verify-issue-detect.sh --git
+VERIFY_BASE_REF=origin/main scripts/claude/verify-issue-detect.sh --git
+```
+
+### 出力フォーマット
+
+| `--format` | 内容 |
+|-----------|------|
+| `flat`（default） | 一行一カテゴリ。重複排除済み。後続フィルタ用 |
+| `manifest` | `<path>: <cat1> <cat2> ...` 形式。path → categories の逆引き構造を維持（5-2 / 5-3 の説明責任用） |
+
+### `--git` モードの base ref 解決順
+
+1. `VERIFY_BASE_REF` 環境変数（指定があれば）
+2. ローカル `main`
+3. `origin/main`
+4. すべて欠ければ exit 1（明確なエラーメッセージ）
+
+CI shallow checkout / 別名 default branch / worktree 配下のいずれでも壊れないこと。
+
+### Make ターゲット
+
+| ターゲット | 動作 |
+|-----------|------|
+| `make verify-issue-detect` | bats fixture を実行。bats 不在時は default で WARN（exit 0）、`CI=true` または `VERIFY_DETECT_REQUIRE_BATS=1` 下では fail（exit 1） |
+| `make shell-lint` | shellcheck（`--severity=warning`）を `verify-issue-detect.sh` 含む `SHELL_FILES` に対して実行 |
+| `make shell-format-check` | shfmt（`-i 2 -ci -bn`）の format 差分を検出 |
+
+---
+
+## 🗺️ 証跡カテゴリ mapping table（派生表）
+
+> **真の SSOT は [`.claude/templates/issue-implementation-plan.md`](../../.claude/templates/issue-implementation-plan.md)「🗺️ 証跡マッピング表」**。
+> 本表はそこからの派生（human-readable）であり、`verify-issue-detect.sh` の anchored regex は本表に従う。
+> 表記揺れ（旧 SubsCore: `presentation/` / `infrastructure/` ↔ 新 docdd-starters: `api/` / `repositories/`）は両方マッチさせる。
+
+| 変更パス（glob 表記、ドキュメント用） | 証跡カテゴリ | 必須証跡 | 自動検知 |
+|------|------------|---------|----------|
+| `apps/backend/app/modules/**/domain/**`, `apps/backend/app/modules/**/services/**` | `backend-unit` | ユニットテスト（pytest） | `make test-backend` |
+| `apps/backend/app/modules/**/repositories/**`, `apps/backend/app/modules/**/infrastructure/**`, `apps/backend/app/infrastructure/**` | `backend-integration` | 統合テスト（DB / 外部連携） | `make test-backend` |
+| `apps/backend/app/modules/**/api/**`, `apps/backend/app/modules/**/presentation/**`, `apps/backend/app/middlewares/**`, `apps/backend/app/shared/**/routes.py` | `api-route` | 統合テスト + API仕様書（6_API）更新 + caller 全件確認 | `make test-backend` + 手動 |
+| `apps/backend/app/**/schemas/**`, `apps/backend/app/contracts/**`, `apps/frontend/**/_types/**`, `apps/frontend/src/types/**` | `api-contract` | Frontend 型一致確認 | 手動 |
+| `apps/backend/app/kernel/**`, `apps/backend/app/shared/**` | `backend-core` | ユニットテスト + 動作確認 | `make test-backend` + 手動 |
+| `apps/backend/alembic/versions/**` | `migration-safety` | up / down / up サイクル | CI |
+| `apps/frontend/app/**/page.tsx`, `apps/frontend/app/**/layout.tsx`, `apps/frontend/app/**/_containers/**`, `apps/frontend/app/**/_components/**`, `apps/frontend/src/components/**` | `frontend-ui` | Vitest OR ブラウザ目視 | `make test-frontend` / 手動 |
+| `apps/frontend/app/**/_hooks/**`, `apps/frontend/app/**/_lib/**`, `apps/frontend/app/**/_actions/**` | `frontend-logic` | Vitest テスト必須 | `make test-frontend` |
+| `apps/frontend/src/lib/**`, `apps/frontend/src/store/**`, `apps/frontend/src/hooks/**` | `frontend-shared` | Vitest テスト必須 | `make test-frontend` |
+| `apps/frontend/app/**/globals.css`, `apps/frontend/tailwind.config.*`, `apps/frontend/postcss.config.*` | `frontend-style` | ブラウザ目視 | 手動 |
+| `docs/7-axis/**`, `docs/testing/traceability/**` | `docdd` | frontmatter + traceability | `make traceability` |
+| `scripts/**`, `Makefile*`, `*.config.*`, `.claude/hooks/**`, `.claude/settings.json`, `.github/**`, `terraform/**` | `dx-config` | 動作確認 + 既存テスト非破壊 | 手動 |
+| `.claude/commands/**`, `.claude/rules/**`, `.claude/skills/**`, `.claude/templates/**`, `.claude/references/**` | `dx-docs` | `make validate-claude` + 目視確認 | `make validate-claude` |
+
+> **glob 表記はドキュメント用**。実装は anchored regex（例: `^apps/backend/app/modules/[^/]+/(domain|services)/`）で `verify-issue-detect.sh` 内に固定する。glob を `grep -E` に直渡しはしない。
+
+---
+
+## 関連
+
+- [.claude/templates/issue-implementation-plan.md](../../.claude/templates/issue-implementation-plan.md) — **真の SSOT**
+- [.claude/skills/verify-input-capture/SKILL.md](../../.claude/skills/verify-input-capture/SKILL.md) — `/verify` Step 1 入力固定
+- [.claude/rules/cli-first.md](../../.claude/rules/cli-first.md) — CLI ファースト原則
+- [Makefile](../../Makefile) — `verify-issue-detect` / `shell-lint` / `shell-format-check` / `test-hooks` / `validate-claude` ターゲット

--- a/scripts/claude/test/verify-issue-detect.bats
+++ b/scripts/claude/test/verify-issue-detect.bats
@@ -61,6 +61,16 @@ teardown() {
   echo "$result" | grep -qx "api-route"
 }
 
+@test "category: api-route (shared/routes.py at zero depth)" {
+  result=$(echo "apps/backend/app/shared/routes.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-route"
+}
+
+@test "category: api-route (shared/<sub>/routes.py at >=1 depth)" {
+  result=$(echo "apps/backend/app/shared/admin/routes.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-route"
+}
+
 # ─── 4. api-contract ──────────────────────────────────────
 
 @test "category: api-contract (modules/<domain>/schemas/)" {
@@ -225,6 +235,30 @@ teardown() {
 
   result=$(VERIFY_BASE_REF=HEAD~1 "$DETECTOR" --git)
   echo "$result" | grep -qx "backend-unit"
+}
+
+# ─── Nested modules (** depth) ────────────────────────────
+
+@test "nested module: modules/<a>/<b>/domain/ -> backend-unit" {
+  result=$(echo "apps/backend/app/modules/billing/invoices/domain/model.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "backend-unit"
+}
+
+@test "nested module: modules/<a>/<b>/repositories/ -> backend-integration" {
+  result=$(echo "apps/backend/app/modules/billing/invoices/repositories/repo.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "backend-integration"
+}
+
+@test "nested module: modules/<a>/<b>/api/ -> api-route" {
+  result=$(echo "apps/backend/app/modules/billing/invoices/api/routes.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-route"
+}
+
+# ─── Near-miss negative ───────────────────────────────────
+
+@test "near-miss: modules/<x>/notdomain/ does NOT emit backend-unit" {
+  result=$(echo "apps/backend/app/modules/example/notdomain/foo.py" | "$DETECTOR" --stdin)
+  ! echo "$result" | grep -qx "backend-unit"
 }
 
 # ─── Shape variation ──────────────────────────────────────

--- a/scripts/claude/test/verify-issue-detect.bats
+++ b/scripts/claude/test/verify-issue-detect.bats
@@ -1,0 +1,279 @@
+#!/usr/bin/env bats
+# scripts/claude/test/verify-issue-detect.bats
+#
+# Fixture tests for scripts/claude/verify-issue-detect.sh (Issue #61).
+#
+# Coverage matrix (per /plan):
+#   - All 13 evidence categories x 1+ case each
+#   - Input modes: --stdin / --files / --git
+#   - Shape variation: presentation/ + infrastructure/ (old SubsCore)
+#                  vs. api/ + repositories/ (new docdd-starters)
+#   - Default-branch fallback (main missing -> origin/main)
+#   - --format manifest (path: categories) and --format flat dedup
+#
+# 真の SSOT: .claude/templates/issue-implementation-plan.md「🗺️ 証跡マッピング表」
+
+DETECTOR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/verify-issue-detect.sh"
+
+setup() {
+  TMPDIR_BATS="$(mktemp -d)"
+}
+
+teardown() {
+  if [[ -n "${TMPDIR_BATS:-}" && -d "$TMPDIR_BATS" ]]; then
+    rm -rf "$TMPDIR_BATS"
+  fi
+}
+
+# ─── 1. backend-unit ──────────────────────────────────────
+
+@test "category: backend-unit (modules/<domain>/domain/)" {
+  result=$(echo "apps/backend/app/modules/example/domain/foo.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "backend-unit"
+}
+
+@test "category: backend-unit (modules/<domain>/services/)" {
+  result=$(echo "apps/backend/app/modules/example/services/foo.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "backend-unit"
+}
+
+# ─── 2. backend-integration ───────────────────────────────
+
+@test "category: backend-integration (modules/<domain>/repositories/)" {
+  result=$(echo "apps/backend/app/modules/example/repositories/repo.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "backend-integration"
+}
+
+@test "category: backend-integration (apps/backend/app/infrastructure/)" {
+  result=$(echo "apps/backend/app/infrastructure/db.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "backend-integration"
+}
+
+# ─── 3. api-route ─────────────────────────────────────────
+
+@test "category: api-route (modules/<domain>/api/)" {
+  result=$(echo "apps/backend/app/modules/example/api/routes.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-route"
+}
+
+@test "category: api-route (middlewares/)" {
+  result=$(echo "apps/backend/app/middlewares/auth.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-route"
+}
+
+# ─── 4. api-contract ──────────────────────────────────────
+
+@test "category: api-contract (modules/<domain>/schemas/)" {
+  result=$(echo "apps/backend/app/modules/example/schemas/user.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-contract"
+}
+
+@test "category: api-contract (contracts/)" {
+  result=$(echo "apps/backend/app/contracts/dto.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-contract"
+}
+
+@test "category: api-contract (frontend src/types/)" {
+  result=$(echo "apps/frontend/src/types/user.ts" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-contract"
+}
+
+@test "category: api-contract (frontend route-local _types/)" {
+  result=$(echo "apps/frontend/app/(main)/dashboard/_types/user.ts" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-contract"
+}
+
+# ─── 5. backend-core ──────────────────────────────────────
+
+@test "category: backend-core (kernel/)" {
+  result=$(echo "apps/backend/app/kernel/config.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "backend-core"
+}
+
+@test "category: backend-core (shared/)" {
+  result=$(echo "apps/backend/app/shared/utils.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "backend-core"
+}
+
+# ─── 6. migration-safety ──────────────────────────────────
+
+@test "category: migration-safety (alembic/versions/)" {
+  result=$(echo "apps/backend/alembic/versions/abc123_add_users.py" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "migration-safety"
+}
+
+# ─── 7. frontend-ui ───────────────────────────────────────
+
+@test "category: frontend-ui (app/**/page.tsx)" {
+  result=$(echo "apps/frontend/app/(main)/dashboard/page.tsx" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "frontend-ui"
+}
+
+@test "category: frontend-ui (app/**/_components/)" {
+  result=$(echo "apps/frontend/app/(main)/dashboard/_components/Header.tsx" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "frontend-ui"
+}
+
+@test "category: frontend-ui (src/components/)" {
+  result=$(echo "apps/frontend/src/components/ui/Button.tsx" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "frontend-ui"
+}
+
+# ─── 8. frontend-logic ────────────────────────────────────
+
+@test "category: frontend-logic (app/**/_hooks/)" {
+  result=$(echo "apps/frontend/app/(main)/dashboard/_hooks/use-foo.ts" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "frontend-logic"
+}
+
+@test "category: frontend-logic (app/**/_actions/)" {
+  result=$(echo "apps/frontend/app/(main)/dashboard/_actions/save.ts" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "frontend-logic"
+}
+
+# ─── 9. frontend-shared ───────────────────────────────────
+
+@test "category: frontend-shared (src/lib/)" {
+  result=$(echo "apps/frontend/src/lib/api-client.ts" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "frontend-shared"
+}
+
+@test "category: frontend-shared (src/store/)" {
+  result=$(echo "apps/frontend/src/store/user.ts" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "frontend-shared"
+}
+
+# ─── 10. frontend-style ───────────────────────────────────
+
+@test "category: frontend-style (app/globals.css)" {
+  result=$(echo "apps/frontend/app/globals.css" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "frontend-style"
+}
+
+@test "category: frontend-style (tailwind.config.ts)" {
+  result=$(echo "apps/frontend/tailwind.config.ts" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "frontend-style"
+}
+
+# ─── 11. docdd ────────────────────────────────────────────
+
+@test "category: docdd (docs/7-axis/)" {
+  result=$(echo "docs/7-axis/3_DM/DM-User.md" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "docdd"
+}
+
+@test "category: docdd (docs/testing/traceability/)" {
+  result=$(echo "docs/testing/traceability/sample_map.json" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "docdd"
+}
+
+# ─── 12. dx-config ────────────────────────────────────────
+
+@test "category: dx-config (scripts/)" {
+  result=$(echo "scripts/bootstrap.sh" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "dx-config"
+}
+
+@test "category: dx-config (Makefile)" {
+  result=$(echo "Makefile" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "dx-config"
+}
+
+@test "category: dx-config (.claude/hooks/)" {
+  result=$(echo ".claude/hooks/block-dangerous.sh" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "dx-config"
+}
+
+# ─── 13. dx-docs ──────────────────────────────────────────
+
+@test "category: dx-docs (.claude/commands/)" {
+  result=$(echo ".claude/commands/plan.md" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "dx-docs"
+}
+
+@test "category: dx-docs (.claude/skills/)" {
+  result=$(echo ".claude/skills/agent-teams/SKILL.md" | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "dx-docs"
+}
+
+# ─── Input modes ──────────────────────────────────────────
+
+@test "input mode: --stdin (multi-line)" {
+  result=$(printf 'apps/backend/app/modules/example/domain/foo.py\ndocs/7-axis/3_DM/DM-User.md\n' | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "backend-unit"
+  echo "$result" | grep -qx "docdd"
+}
+
+@test "input mode: --files (multiple args)" {
+  result=$("$DETECTOR" --files "apps/backend/app/modules/example/domain/foo.py" "docs/7-axis/3_DM/DM-User.md")
+  echo "$result" | grep -qx "backend-unit"
+  echo "$result" | grep -qx "docdd"
+}
+
+@test "input mode: --git (with VERIFY_BASE_REF override)" {
+  cd "$TMPDIR_BATS"
+  git init -q
+  git config user.email "bats@test"
+  git config user.name "bats"
+  mkdir -p apps/backend/app/modules/example/domain
+  echo "v1" > apps/backend/app/modules/example/domain/foo.py
+  git add -A
+  git commit -q -m "init"
+  echo "v2" > apps/backend/app/modules/example/domain/foo.py
+  git add -A
+  git commit -q -m "change"
+
+  result=$(VERIFY_BASE_REF=HEAD~1 "$DETECTOR" --git)
+  echo "$result" | grep -qx "backend-unit"
+}
+
+# ─── Shape variation ──────────────────────────────────────
+
+@test "shape variation: old SubsCore (presentation/ + infrastructure/) detected" {
+  result=$(printf 'apps/backend/app/modules/example/presentation/route.py\napps/backend/app/modules/example/infrastructure/repo.py\n' | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-route"
+  echo "$result" | grep -qx "backend-integration"
+}
+
+@test "shape variation: new docdd-starters (api/ + repositories/) detected" {
+  result=$(printf 'apps/backend/app/modules/example/api/routes.py\napps/backend/app/modules/example/repositories/repo.py\n' | "$DETECTOR" --stdin)
+  echo "$result" | grep -qx "api-route"
+  echo "$result" | grep -qx "backend-integration"
+}
+
+# ─── Default-branch fallback (--git) ──────────────────────
+
+@test "default-branch fallback: missing main, falls back to origin/main" {
+  cd "$TMPDIR_BATS"
+  git init -q -b feature
+  git config user.email "bats@test"
+  git config user.name "bats"
+  mkdir -p apps/backend/app/modules/example/domain
+  echo "v1" > apps/backend/app/modules/example/domain/foo.py
+  git add -A
+  git commit -q -m "init"
+
+  # Simulate origin/main pointing to the initial commit; no local main branch.
+  git update-ref refs/remotes/origin/main HEAD
+
+  echo "v2" > apps/backend/app/modules/example/domain/foo.py
+  git add -A
+  git commit -q -m "change"
+
+  unset VERIFY_BASE_REF || true
+  result=$("$DETECTOR" --git)
+  echo "$result" | grep -qx "backend-unit"
+}
+
+# ─── Output format ────────────────────────────────────────
+
+@test "format: --format manifest emits 'path: categories'" {
+  result=$(echo "apps/backend/app/modules/example/domain/foo.py" | "$DETECTOR" --stdin --format manifest)
+  echo "$result" | grep -qx "apps/backend/app/modules/example/domain/foo.py: backend-unit"
+}
+
+@test "format: --format flat dedupes categories" {
+  result=$(printf 'apps/backend/app/modules/example/domain/a.py\napps/backend/app/modules/example/domain/b.py\n' | "$DETECTOR" --stdin)
+  count=$(echo "$result" | grep -cx "backend-unit")
+  [ "$count" -eq 1 ]
+}

--- a/scripts/claude/verify-issue-detect.sh
+++ b/scripts/claude/verify-issue-detect.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# scripts/claude/verify-issue-detect.sh
+#
+# Change-aware verification detector. Maps changed paths to required
+# evidence categories used by `/verify` and `make verify-issue` (5-2 / 5-3).
+#
+# 真の SSOT: .claude/templates/issue-implementation-plan.md「🗺️ 証跡マッピング表」
+# 派生表 (human-readable): scripts/claude/README.md
+# 実装 (this file) は派生表に従う。drift 検知の自動化は Phase F 後続。
+#
+# Usage:
+#   verify-issue-detect.sh --stdin [--format flat|manifest]
+#   verify-issue-detect.sh --files <path...> [--format flat|manifest]
+#   verify-issue-detect.sh --git [--format flat|manifest]
+#
+# Env (--git mode):
+#   VERIFY_BASE_REF  Override base ref for `git merge-base ... HEAD`.
+#                    Resolution order: VERIFY_BASE_REF -> main -> origin/main.
+#                    All-miss => exit 1 with a clear error.
+#
+# Output:
+#   --format flat (default): one category per line, deduped, no path context.
+#   --format manifest:       `<path>: <cat1> <cat2> ...` per matched path.
+
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  verify-issue-detect.sh --stdin [--format flat|manifest]
+  verify-issue-detect.sh --files <path...> [--format flat|manifest]
+  verify-issue-detect.sh --git [--format flat|manifest]
+
+Reads changed paths and emits required evidence categories.
+
+Env (--git mode):
+  VERIFY_BASE_REF  Override base ref. Resolution: VERIFY_BASE_REF -> main -> origin/main.
+EOF
+}
+
+err() { printf 'ERROR: %s\n' "$*" >&2; }
+
+# ─── Categorize a single path. Echoes 0..N category names, one per line. ───
+categorize_path() {
+  local path="$1"
+  local re
+
+  # 1. backend-unit
+  re='^apps/backend/app/modules/[^/]+/(domain|services)/'
+  if [[ "$path" =~ $re ]]; then
+    echo "backend-unit"
+  fi
+
+  # 2. backend-integration
+  re='^apps/backend/app/modules/[^/]+/(repositories|infrastructure)/'
+  if [[ "$path" =~ $re ]] || [[ "$path" =~ ^apps/backend/app/infrastructure/ ]]; then
+    echo "backend-integration"
+  fi
+
+  # 3. api-route
+  re='^apps/backend/app/modules/[^/]+/(api|presentation)/'
+  if [[ "$path" =~ $re ]] \
+    || [[ "$path" =~ ^apps/backend/app/middlewares/ ]] \
+    || [[ "$path" =~ ^apps/backend/app/shared/.*/routes\.py$ ]]; then
+    echo "api-route"
+  fi
+
+  # 4. api-contract
+  if [[ "$path" =~ ^apps/backend/app/.*/schemas/ ]] \
+    || [[ "$path" =~ ^apps/backend/app/contracts/ ]] \
+    || [[ "$path" =~ ^apps/frontend/app/.*/_types/ ]] \
+    || [[ "$path" =~ ^apps/frontend/app/_types/ ]] \
+    || [[ "$path" =~ ^apps/frontend/src/types/ ]]; then
+    echo "api-contract"
+  fi
+
+  # 5. backend-core
+  if [[ "$path" =~ ^apps/backend/app/kernel/ ]] \
+    || [[ "$path" =~ ^apps/backend/app/shared/ ]]; then
+    echo "backend-core"
+  fi
+
+  # 6. migration-safety
+  if [[ "$path" =~ ^apps/backend/alembic/versions/ ]]; then
+    echo "migration-safety"
+  fi
+
+  # 7. frontend-ui
+  re='^apps/frontend/app/(.*/)?(page|layout)\.tsx$'
+  if [[ "$path" =~ $re ]] \
+    || [[ "$path" =~ ^apps/frontend/app/.*/_(containers|components)/ ]] \
+    || [[ "$path" =~ ^apps/frontend/app/_(containers|components)/ ]] \
+    || [[ "$path" =~ ^apps/frontend/src/components/ ]]; then
+    echo "frontend-ui"
+  fi
+
+  # 8. frontend-logic
+  if [[ "$path" =~ ^apps/frontend/app/.*/_(hooks|lib|actions)/ ]] \
+    || [[ "$path" =~ ^apps/frontend/app/_(hooks|lib|actions)/ ]]; then
+    echo "frontend-logic"
+  fi
+
+  # 9. frontend-shared
+  if [[ "$path" =~ ^apps/frontend/src/(lib|store|hooks)/ ]]; then
+    echo "frontend-shared"
+  fi
+
+  # 10. frontend-style
+  re='^apps/frontend/app/(.*/)?globals\.css$'
+  if [[ "$path" =~ $re ]] \
+    || [[ "$path" =~ ^apps/frontend/tailwind\.config\. ]] \
+    || [[ "$path" =~ ^apps/frontend/postcss\.config\. ]]; then
+    echo "frontend-style"
+  fi
+
+  # 11. docdd
+  if [[ "$path" =~ ^docs/7-axis/ ]] \
+    || [[ "$path" =~ ^docs/testing/traceability/ ]]; then
+    echo "docdd"
+  fi
+
+  # 12. dx-config
+  if [[ "$path" =~ ^scripts/ ]] \
+    || [[ "$path" =~ ^Makefile ]] \
+    || [[ "$path" =~ ^[^/]+\.config\. ]] \
+    || [[ "$path" =~ ^\.claude/hooks/ ]] \
+    || [[ "$path" == ".claude/settings.json" ]] \
+    || [[ "$path" =~ ^\.github/ ]] \
+    || [[ "$path" =~ ^terraform/ ]]; then
+    echo "dx-config"
+  fi
+
+  # 13. dx-docs
+  if [[ "$path" =~ ^\.claude/(commands|rules|skills|templates|references)/ ]]; then
+    echo "dx-docs"
+  fi
+}
+
+# ─── Resolve --git base ref. Echoes ref to stdout; errors to stderr. ───
+resolve_base_ref() {
+  if [[ -n "${VERIFY_BASE_REF:-}" ]]; then
+    if git rev-parse --verify --quiet "$VERIFY_BASE_REF" >/dev/null; then
+      echo "$VERIFY_BASE_REF"
+      return 0
+    fi
+    err "VERIFY_BASE_REF='$VERIFY_BASE_REF' not found in repo"
+    return 1
+  fi
+  if git rev-parse --verify --quiet main >/dev/null; then
+    echo "main"
+    return 0
+  fi
+  if git rev-parse --verify --quiet origin/main >/dev/null; then
+    echo "origin/main"
+    return 0
+  fi
+  err "cannot resolve base ref (tried VERIFY_BASE_REF / main / origin/main)"
+  return 1
+}
+
+# ─── Collect input paths into stdout (newline-separated). ───
+collect_paths() {
+  case "$INPUT_MODE" in
+    stdin)
+      cat
+      ;;
+    files)
+      local f
+      for f in "${FILES[@]}"; do
+        printf '%s\n' "$f"
+      done
+      ;;
+    git)
+      local base_ref merge_base
+      if ! base_ref=$(resolve_base_ref); then
+        return 1
+      fi
+      if ! merge_base=$(git merge-base "$base_ref" HEAD 2>/dev/null); then
+        err "git merge-base $base_ref HEAD failed"
+        return 1
+      fi
+      git diff --name-only "$merge_base" HEAD
+      ;;
+  esac
+}
+
+# ─── Argument parsing ───
+INPUT_MODE=""
+FORMAT="flat"
+FILES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stdin)
+      INPUT_MODE="stdin"
+      shift
+      ;;
+    --files)
+      INPUT_MODE="files"
+      shift
+      while [[ $# -gt 0 && "$1" != --* ]]; do
+        FILES+=("$1")
+        shift
+      done
+      ;;
+    --git)
+      INPUT_MODE="git"
+      shift
+      ;;
+    --format)
+      if [[ $# -lt 2 ]]; then
+        err "--format requires a value (flat|manifest)"
+        exit 1
+      fi
+      FORMAT="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      err "unknown argument: $1"
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$INPUT_MODE" ]]; then
+  err "input mode required (--stdin / --files / --git)"
+  usage >&2
+  exit 1
+fi
+
+if [[ "$FORMAT" != "flat" && "$FORMAT" != "manifest" ]]; then
+  err "--format must be 'flat' or 'manifest' (got '$FORMAT')"
+  exit 1
+fi
+
+# ─── Run ───
+if ! ALL_PATHS=$(collect_paths); then
+  exit 1
+fi
+
+case "$FORMAT" in
+  flat)
+    {
+      while IFS= read -r p; do
+        [[ -z "$p" ]] && continue
+        categorize_path "$p"
+      done <<<"$ALL_PATHS"
+    } | awk 'NF && !seen[$0]++'
+    ;;
+  manifest)
+    while IFS= read -r p; do
+      [[ -z "$p" ]] && continue
+      cats=$(categorize_path "$p" | awk 'NF && !seen[$0]++' | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+      if [[ -n "$cats" ]]; then
+        printf '%s: %s\n' "$p" "$cats"
+      fi
+    done <<<"$ALL_PATHS"
+    ;;
+esac

--- a/scripts/claude/verify-issue-detect.sh
+++ b/scripts/claude/verify-issue-detect.sh
@@ -18,6 +18,10 @@
 #                    Resolution order: VERIFY_BASE_REF -> main -> origin/main.
 #                    All-miss => exit 1 with a clear error.
 #
+# Scope of --git:
+#   Diffs `merge-base..HEAD` only; staged / working-tree / untracked changes
+#   are out of scope. Use --stdin or --files for pre-commit local detection.
+#
 # Output:
 #   --format flat (default): one category per line, deduped, no path context.
 #   --format manifest:       `<path>: <cat1> <cat2> ...` per matched path.
@@ -46,22 +50,26 @@ categorize_path() {
   local re
 
   # 1. backend-unit
-  re='^apps/backend/app/modules/[^/]+/(domain|services)/'
+  # Use `.+` (not `[^/]+`) to match nested modules per the documented `**` glob
+  # (e.g. apps/backend/app/modules/billing/invoices/domain/...).
+  re='^apps/backend/app/modules/.+/(domain|services)/'
   if [[ "$path" =~ $re ]]; then
     echo "backend-unit"
   fi
 
   # 2. backend-integration
-  re='^apps/backend/app/modules/[^/]+/(repositories|infrastructure)/'
+  re='^apps/backend/app/modules/.+/(repositories|infrastructure)/'
   if [[ "$path" =~ $re ]] || [[ "$path" =~ ^apps/backend/app/infrastructure/ ]]; then
     echo "backend-integration"
   fi
 
   # 3. api-route
-  re='^apps/backend/app/modules/[^/]+/(api|presentation)/'
+  # `shared/(.*/)?routes.py$` to also match zero-depth `shared/routes.py`
+  # (the documented `**` glob includes zero or more directories).
+  re='^apps/backend/app/modules/.+/(api|presentation)/'
   if [[ "$path" =~ $re ]] \
     || [[ "$path" =~ ^apps/backend/app/middlewares/ ]] \
-    || [[ "$path" =~ ^apps/backend/app/shared/.*/routes\.py$ ]]; then
+    || [[ "$path" =~ ^apps/backend/app/shared/(.*/)?routes\.py$ ]]; then
     echo "api-route"
   fi
 


### PR DESCRIPTION
## 変更内容

- **Wave 5-1: change-aware verification の detector 追加**（DX ツーリング Issue。Backend / Frontend / DocDD 配下は変更なし）
- `scripts/claude/verify-issue-detect.sh`: 変更パスを入力に必要証跡カテゴリを stdout に列挙する純粋関数。入力モード 3 種（`--stdin` / `--files` / `--git`）+ 出力フォーマット 2 種（`flat` / `manifest`）。`--git` は `VERIFY_BASE_REF` env → `main` → `origin/main` の 3 段階 fallback
- `scripts/claude/test/verify-issue-detect.bats`: 全 13 証跡カテゴリ × 各 1+ ケース + 入力モード smoke 3 + 表記揺れ 2 + default-branch fallback 1 + format manifest 2 + nested module 3 + `shared/routes.py` zero/one-depth 2 + near-miss negative 1 = **43 tests**
- `scripts/claude/README.md`: `scripts/claude/` 配下スクリプト一覧 + 証跡カテゴリ mapping table の派生表（真の SSOT は `.claude/templates/issue-implementation-plan.md` と冒頭で明示）
- `Makefile`: `verify-issue-detect` target 追加（bats 不在時は local default WARN / `CI=true` または `VERIFY_DETECT_REQUIRE_BATS=1` で fail-fast）+ `SHELL_FILES` に追記
- **既存挙動の変化**: なし（新規 target / 新規スクリプト / 新規 fixture のみ）。`SHELL_FILES` 追記により `make shell-lint` / `make shell-format-check` の対象が 1 ファイル増える
- **後続スライス**: 5-2（`make verify-issue` 6 ステップ統合）、5-3（`/verify` 構造化投稿）

## 仕様メモ（後続 5-2 / 5-3 のための解釈ガイド）

- **anchored regex は `[^/]+` ではなく `.+`**（nested module 対応）。`apps/backend/app/modules/<a>/<b>/domain/...` のようなネスト配置でも `backend-unit` を出す
- **副作用なし**: detector は test 実行 / quality-gate 呼び出し / GitHub API 呼び出しを含まない（SubsCore verify-issue.sh の Step 1 + Step 2 のみ切り出し）
- **`--git` のスコープ**: コミット済差分のみ（merge-base..HEAD）。pre-commit / staging 段階の差分には `--stdin` / `--files` を使う（detector ヘッダ + README に doc note あり）
- **表記揺れ吸収**: SubsCore 旧 `presentation/` / `infrastructure/` と docdd-starters 新 `api/` / `repositories/` の両方が同じカテゴリを出す

## テスト

- [x] `make verify-issue-detect`（PASS / 43 tests）
- [x] `make shell-lint`（PASS）
- [x] `make shell-format-check`（PASS）
- [x] `make test-hooks`（PASS / 9 tests / 既存 fixture 非破壊確認）
- [x] `make validate-claude`（PASS / 既存 20 warnings は本 Issue 起因ではない pre-existing）
- [x] `make traceability`（PASS / DocDD 変更なしの回帰確認）
- [ ] `make test-backend` / `make test-frontend`（N/A — Backend / Frontend 配下に変更なし）
- [ ] ブラウザヘルスチェック（N/A — UI 変更なし）

## DocDD 7軸

更新なし（DX ツーリング Issue。BR / UC / DM / SR / EXT / API / TC への影響なし）。

## 関連

Closes #61

Refs Epic #23 / 依存 #51 / 後続 5-2 / 5-3
