### PR TITLE
feat(scripts): add make verify-issue 6-step orchestrator (#62)

### DIFF
--- a/.claude/templates/verify-issue-result.json
+++ b/.claude/templates/verify-issue-result.json
@@ -12,12 +12,12 @@
       "started_at": "string — ISO8601 UTC (YYYY-MM-DDThh:mm:ssZ)",
       "finished_at": "string — ISO8601 UTC"
     },
-    "steps": "array of step objects (see steps[0] below). Same make target is invoked at most once per run (dedup).",
+    "steps": "array of step objects (see steps[0] below). Same make target is invoked at most once per run (dedup). In ADDITION to automated steps, a manual_required placeholder step (command null, status skip, skip_reason manual_required, name <category>-manual) is appended for every detected category whose SSOT mapping requires manual evidence (api-route, api-contract, backend-core, frontend-ui, frontend-style, docdd, dx-config, dx-docs). These are additive — an automated target passing does NOT clear the category's manual placeholder. migration-safety is the exception: its manual aspect is the partial+notes flag on test-backend, not a separate placeholder.",
     "summary": {
       "pass_count": "int — steps with status == pass",
       "fail_count": "int — steps with status == fail",
       "skip_count": "int — steps with status == skip",
-      "manual_required_count": "int — skip steps whose skip_reason == manual_required",
+      "manual_required_count": "int — skip steps whose skip_reason == manual_required; >0 means 5-3 must surface pending manual evidence even when exit_code == 0",
       "partial_count": "int — steps with partial == true (e.g. migration-safety up/down not validated)",
       "total_count": "int — total recorded steps"
     },
@@ -79,7 +79,21 @@
       "stderr_path": null,
       "skip_reason": "manual_required",
       "partial": false,
-      "notes": null,
+      "notes": "Browser visual check (mandatory)",
+      "started_at": "2026-05-16T04:02:55Z",
+      "finished_at": "2026-05-16T04:02:55Z"
+    },
+    {
+      "name": "docdd-manual",
+      "categories": ["docdd"],
+      "command": null,
+      "status": "skip",
+      "exit_code": null,
+      "stdout_path": null,
+      "stderr_path": null,
+      "skip_reason": "manual_required",
+      "partial": false,
+      "notes": "frontmatter visual check",
       "started_at": "2026-05-16T04:02:55Z",
       "finished_at": "2026-05-16T04:02:55Z"
     }
@@ -87,10 +101,10 @@
   "summary": {
     "pass_count": 1,
     "fail_count": 1,
-    "skip_count": 1,
-    "manual_required_count": 1,
+    "skip_count": 2,
+    "manual_required_count": 2,
     "partial_count": 1,
-    "total_count": 3
+    "total_count": 4
   },
   "error": {
     "code": null,

--- a/.claude/templates/verify-issue-result.json
+++ b/.claude/templates/verify-issue-result.json
@@ -1,0 +1,102 @@
+{
+  "_schema": {
+    "_doc": "Result schema produced by scripts/claude/verify-issue.sh (Wave 5-2). This file is the SSOT contract that Wave 5-3 (/verify structured posting) parses. Field names, types and enum values below are normative; the values are a representative example, not literal output. drift between this template and the orchestrator must be treated as a bug.",
+    "inputs": {
+      "requested_issue": "int — the ISSUE number passed to the orchestrator",
+      "resolved_pr": "int | null — PR number resolved from `gh pr list --head <branch>`; null when no PR exists yet",
+      "issue_pr_match": "bool — true when the resolved PR body/title references #<requested_issue> (Closes/Fixes/Resolves/#N)",
+      "source": "\"pr-diff\" | \"merge-base-fallback\" | null — how the changed paths were obtained; null on prerequisite failure before resolution",
+      "run_id": "string — unique id for this run (pid + epoch)",
+      "pid": "int — orchestrator process id",
+      "output_path": "string — absolute path this JSON was written to",
+      "started_at": "string — ISO8601 UTC (YYYY-MM-DDThh:mm:ssZ)",
+      "finished_at": "string — ISO8601 UTC"
+    },
+    "steps": "array of step objects (see steps[0] below). Same make target is invoked at most once per run (dedup).",
+    "summary": {
+      "pass_count": "int — steps with status == pass",
+      "fail_count": "int — steps with status == fail",
+      "skip_count": "int — steps with status == skip",
+      "manual_required_count": "int — skip steps whose skip_reason == manual_required",
+      "partial_count": "int — steps with partial == true (e.g. migration-safety up/down not validated)",
+      "total_count": "int — total recorded steps"
+    },
+    "error": {
+      "code": "string | null — one of: jq_not_found (stderr-only, no JSON) | gh_pr_lookup_failed | pr_issue_mismatch | detector_failed | unknown_category | null when no prerequisite failure",
+      "message": "string | null — human-readable error message",
+      "detector_stderr": "string | null — captured stderr of verify-issue-detect.sh when error.code == detector_failed"
+    },
+    "warnings": "array of strings — non-fatal observations (e.g. pr_issue_mismatch when VERIFY_REQUIRE_PR_MATCH=0)",
+    "exit_code": "int — the orchestrator's final exit code, also logged inside the JSON (0 pass | 1 step failed | 2 arg invalid | 3 prerequisite failure)"
+  },
+  "inputs": {
+    "requested_issue": 62,
+    "resolved_pr": 100,
+    "issue_pr_match": true,
+    "source": "pr-diff",
+    "run_id": "48213-1747900000",
+    "pid": 48213,
+    "output_path": "/tmp/verify-issue-62.aB3xQ7.json",
+    "started_at": "2026-05-16T04:00:00Z",
+    "finished_at": "2026-05-16T04:03:21Z"
+  },
+  "steps": [
+    {
+      "name": "test-backend",
+      "categories": ["backend-unit", "migration-safety"],
+      "command": "make test-backend",
+      "status": "pass",
+      "exit_code": 0,
+      "stdout_path": "/tmp/verify-issue-62.48213.test-backend.stdout",
+      "stderr_path": "/tmp/verify-issue-62.48213.test-backend.stderr",
+      "skip_reason": null,
+      "partial": true,
+      "notes": "up/down not validated",
+      "started_at": "2026-05-16T04:00:01Z",
+      "finished_at": "2026-05-16T04:02:10Z"
+    },
+    {
+      "name": "traceability",
+      "categories": ["docdd"],
+      "command": "make traceability",
+      "status": "fail",
+      "exit_code": 1,
+      "stdout_path": "/tmp/verify-issue-62.48213.traceability.stdout",
+      "stderr_path": "/tmp/verify-issue-62.48213.traceability.stderr",
+      "skip_reason": null,
+      "partial": false,
+      "notes": null,
+      "started_at": "2026-05-16T04:02:10Z",
+      "finished_at": "2026-05-16T04:02:55Z"
+    },
+    {
+      "name": "frontend-style-manual",
+      "categories": ["frontend-style"],
+      "command": null,
+      "status": "skip",
+      "exit_code": null,
+      "stdout_path": null,
+      "stderr_path": null,
+      "skip_reason": "manual_required",
+      "partial": false,
+      "notes": null,
+      "started_at": "2026-05-16T04:02:55Z",
+      "finished_at": "2026-05-16T04:02:55Z"
+    }
+  ],
+  "summary": {
+    "pass_count": 1,
+    "fail_count": 1,
+    "skip_count": 1,
+    "manual_required_count": 1,
+    "partial_count": 1,
+    "total_count": 3
+  },
+  "error": {
+    "code": null,
+    "message": null,
+    "detector_stderr": null
+  },
+  "warnings": [],
+  "exit_code": 1
+}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: tf-init tf-plan tf-apply tf-destroy tf-output
 .PHONY: deploy-backend-stg deploy-frontend-stg deploy-stg deploy-backend-prod deploy-frontend-prod deploy-prod
 .PHONY: ecs-status ecs-logs-backend ecs-logs-frontend ecs-sh
-.PHONY: shell-lint shell-format-check test-hooks verify-issue-detect
+.PHONY: shell-lint shell-format-check test-hooks verify-issue-detect verify-issue verify-issue-fixture
 .PHONY: validate-claude
 
 PYTHON ?= python3
@@ -61,6 +61,7 @@ SHELL_FILES := .claude/hooks/block-dangerous.sh \
 	scripts/claude/detect-capabilities.sh \
 	scripts/claude/validate-claude-config.sh \
 	scripts/claude/verify-issue-detect.sh \
+	scripts/claude/verify-issue.sh \
 	scripts/deploy/terraform.sh \
 	scripts/deploy/build-and-deploy.sh \
 	scripts/github/bootstrap-labels.sh
@@ -94,6 +95,19 @@ verify-issue-detect:
 		exit 1; \
 	else \
 		echo "WARN: bats not found, skipping verify-issue-detect"; \
+	fi
+
+verify-issue:
+	@scripts/claude/verify-issue.sh $(ISSUE) $(ARGS)
+
+verify-issue-fixture:
+	@if command -v bats >/dev/null 2>&1; then \
+		bats scripts/claude/test/verify-issue.bats; \
+	elif [ "$$CI" = "true" ] || [ "$$VERIFY_ISSUE_FIXTURE_REQUIRE_BATS" = "1" ]; then \
+		echo "ERROR: bats not found (required when CI=true or VERIFY_ISSUE_FIXTURE_REQUIRE_BATS=1)"; \
+		exit 1; \
+	else \
+		echo "WARN: bats not found, skipping verify-issue-fixture"; \
 	fi
 
 # ─── Terraform ───────────────────────────────────────────

--- a/scripts/claude/README.md
+++ b/scripts/claude/README.md
@@ -31,16 +31,18 @@ Claude Code / DocDD ワークフローを支えるスクリプト群。
 | `detect-capabilities.sh` | gh / codex / pencil / aws 等の利用可否を JSON で出力 | `scripts/bootstrap.sh` |
 | `validate-claude-config.sh` | `.claude/` 配下の構成・命名・frontmatter を検証 | `make validate-claude` |
 | `validate_claude_frontmatter.py` | skill / command の frontmatter スキーマ検証 | `validate-claude-config.sh` 内部 |
-| `verify-issue-detect.sh` | 変更パスから必要証跡カテゴリを列挙する change-aware detector | `make verify-issue-detect`、5-2 / 5-3（後続 Issue） |
+| `verify-issue-detect.sh` | 変更パスから必要証跡カテゴリを列挙する change-aware detector | `make verify-issue-detect`、`verify-issue.sh`（5-2）、5-3（後続 Issue） |
+| `verify-issue.sh` | Issue 番号 → PR 解決 → detector → カテゴリ別検証 → 構造化 JSON 出力の 6 ステップ orchestrator | `make verify-issue`、5-3（後続 Issue） |
 | `test-hooks.bats` | `.claude/hooks/` の bats fixture | `make test-hooks` |
 | `test/verify-issue-detect.bats` | `verify-issue-detect.sh` の bats fixture | `make verify-issue-detect` |
+| `test/verify-issue.bats` | `verify-issue.sh` の bats fixture（25 ケース） | `make verify-issue-fixture` |
 
 ---
 
 ## verify-issue-detect.sh
 
 変更パスを入力に、必要な証跡カテゴリを stdout に列挙する純粋関数。
-`/verify` と `make verify-issue`（5-2 で導入予定）の前段で使う。
+`/verify` と `make verify-issue`（5-2 で導入済み — 下記 `verify-issue.sh` 節）の前段で使う。
 
 ### 使い方
 
@@ -116,9 +118,59 @@ CI shallow checkout / 別名 default branch / worktree 配下のいずれでも�
 
 ---
 
+## verify-issue.sh
+
+Issue 番号を起点に 6 ステップを直列実行する orchestrator（Wave 5-2）。
+`verify-issue-detect.sh`（5-1）を呼び出してカテゴリを検出し、カテゴリごとの検証を実行して構造化 JSON を出力する。
+
+| ステップ | 内容 |
+|---------|------|
+| 0 | 前提チェック（`jq` 存在確認） |
+| 1 | Issue → PR 解決 + ISSUE-PR 紐付け検証（PR 本文/タイトルの `Closes/Fixes/Resolves #<N>` / `#<N>`） |
+| 2 | `verify-issue-detect.sh` でカテゴリ検出（PR あり: `--stdin` / PR なし: `--git` fallback） |
+| 3 | カテゴリ → make target を **dedup** して順次実行（stop-on-fail = 続行） |
+| 4 | 集約（`pass/fail/skip/manual_required/partial/total` の 5+1 統計） |
+| 5 | 構造化 JSON 出力（atomic write + `.latest.json` symlink）+ exit code |
+
+### 使い方
+
+```bash
+# 位置引数（SubsCore 流）
+scripts/claude/verify-issue.sh 62
+# ISSUE env でも可（位置引数が無いとき）
+ISSUE=62 scripts/claude/verify-issue.sh
+# Makefile 経由
+make verify-issue ISSUE=62
+```
+
+### 環境変数
+
+| 環境変数 | 既定値 | 効果 |
+|---------|:----:|------|
+| `VERIFY_ISSUE_OUTPUT` | （mktemp） | 出力 JSON パスを上書き。未指定時は `$(mktemp "$TMPDIR/verify-issue-<N>.XXXXXX").json` |
+| `VERIFY_REQUIRE_PR_MATCH` | `1` | `0` で ISSUE-PR 不一致を warning に降格（exit 3 にしない） |
+| `VERIFY_ISSUE_DETECTOR` | 同階層の `verify-issue-detect.sh` | detector スクリプトパスを上書き（テスト用） |
+
+### 出力 / exit code
+
+- 出力 JSON の schema SSOT は [`.claude/templates/verify-issue-result.json`](../../.claude/templates/verify-issue-result.json)（5-3 との契約）。`.latest.json` symlink で最新 run を辿れる
+- step の stdout/stderr 本文は別ファイルに退避し、JSON には path のみ記録（巨大ログ / 制御文字による JSON 破壊を構造的に回避）
+- exit code: `0` 全 PASS（SKIP のみ含む） / `1` 1 件以上 FAIL / `2` 引数不正（ISSUE 未指定 / 非数字 / `0`） / `3` 前提失敗（`jq` 不在 / detector 不在・異常終了 / unknown_category / `gh pr list` 失敗 / ISSUE-PR 不一致）
+- detector の `exit 1` は orchestrator 側で `exit 3` + `error.code = "detector_failed"` に変換（detector 本体は 5-1 baseline として改変しない）
+
+### Make ターゲット
+
+| ターゲット | 動作 |
+|-----------|------|
+| `make verify-issue ISSUE=<N> [ARGS=...]` | orchestrator を起動。`ARGS` は将来の opt-in 拡張用 pass-through |
+| `make verify-issue-fixture` | bats fixture（25 ケース）を実行。bats 不在時は default で WARN（exit 0）、`CI=true` または `VERIFY_ISSUE_FIXTURE_REQUIRE_BATS=1` 下では fail（exit 1） |
+
+---
+
 ## 関連
 
 - [.claude/templates/issue-implementation-plan.md](../../.claude/templates/issue-implementation-plan.md) — **真の SSOT**
 - [.claude/skills/verify-input-capture/SKILL.md](../../.claude/skills/verify-input-capture/SKILL.md) — `/verify` Step 1 入力固定
 - [.claude/rules/cli-first.md](../../.claude/rules/cli-first.md) — CLI ファースト原則
-- [Makefile](../../Makefile) — `verify-issue-detect` / `shell-lint` / `shell-format-check` / `test-hooks` / `validate-claude` ターゲット
+- [.claude/templates/verify-issue-result.json](../../.claude/templates/verify-issue-result.json) — `verify-issue.sh` 出力 JSON schema SSOT（5-3 契約）
+- [Makefile](../../Makefile) — `verify-issue` / `verify-issue-fixture` / `verify-issue-detect` / `shell-lint` / `shell-format-check` / `test-hooks` / `validate-claude` ターゲット

--- a/scripts/claude/README.md
+++ b/scripts/claude/README.md
@@ -35,7 +35,7 @@ Claude Code / DocDD ワークフローを支えるスクリプト群。
 | `verify-issue.sh` | Issue 番号 → PR 解決 → detector → カテゴリ別検証 → 構造化 JSON 出力の 6 ステップ orchestrator | `make verify-issue`、5-3（後続 Issue） |
 | `test-hooks.bats` | `.claude/hooks/` の bats fixture | `make test-hooks` |
 | `test/verify-issue-detect.bats` | `verify-issue-detect.sh` の bats fixture | `make verify-issue-detect` |
-| `test/verify-issue.bats` | `verify-issue.sh` の bats fixture（25 ケース） | `make verify-issue-fixture` |
+| `test/verify-issue.bats` | `verify-issue.sh` の bats fixture（29 ケース） | `make verify-issue-fixture` |
 
 ---
 
@@ -157,13 +157,14 @@ make verify-issue ISSUE=62
 - step の stdout/stderr 本文は別ファイルに退避し、JSON には path のみ記録（巨大ログ / 制御文字による JSON 破壊を構造的に回避）
 - exit code: `0` 全 PASS（SKIP のみ含む） / `1` 1 件以上 FAIL / `2` 引数不正（ISSUE 未指定 / 非数字 / `0`） / `3` 前提失敗（`jq` 不在 / detector 不在・異常終了 / unknown_category / `gh pr list` 失敗 / ISSUE-PR 不一致）
 - detector の `exit 1` は orchestrator 側で `exit 3` + `error.code = "detector_failed"` に変換（detector 本体は 5-1 baseline として改変しない）
+- 手動証跡を要するカテゴリ（api-route / api-contract / backend-core / frontend-ui / frontend-style / docdd / dx-config / dx-docs）は自動 step に **加算** で `<category>-manual` プレースホルダ step（`skip_reason: "manual_required"`）を出力し `summary.manual_required_count` に計上。自動 target が PASS しても手動確認は消えない（5-3 が可視化）。migration-safety のみ例外で partial+notes で表現
 
 ### Make ターゲット
 
 | ターゲット | 動作 |
 |-----------|------|
 | `make verify-issue ISSUE=<N> [ARGS=...]` | orchestrator を起動。`ARGS` は将来の opt-in 拡張用 pass-through |
-| `make verify-issue-fixture` | bats fixture（25 ケース）を実行。bats 不在時は default で WARN（exit 0）、`CI=true` または `VERIFY_ISSUE_FIXTURE_REQUIRE_BATS=1` 下では fail（exit 1） |
+| `make verify-issue-fixture` | bats fixture（29 ケース）を実行。bats 不在時は default で WARN（exit 0）、`CI=true` または `VERIFY_ISSUE_FIXTURE_REQUIRE_BATS=1` 下では fail（exit 1） |
 
 ---
 

--- a/scripts/claude/test/verify-issue.bats
+++ b/scripts/claude/test/verify-issue.bats
@@ -1,0 +1,421 @@
+#!/usr/bin/env bats
+# scripts/claude/test/verify-issue.bats
+#
+# RED fixture for scripts/claude/verify-issue.sh (Issue #62, /tdd phase).
+# The orchestrator does NOT exist yet — every test here MUST fail until
+# /develop implements scripts/claude/verify-issue.sh + the Makefile targets.
+#
+# Encoded orchestrator contract (the GREEN target /develop must satisfy):
+#
+#   Invocation
+#     verify-issue.sh <ISSUE> [args]      # SubsCore-style positional model
+#     ISSUE env is used when the positional arg is absent.
+#
+#   Exit codes (orchestrator-own regime; NOT the detector's regime)
+#     0  all steps pass (or skip-only)
+#     1  at least one step failed (stop-on-fail = CONTINUE: all steps still run)
+#     2  argument invalid (ISSUE missing / non-digits / "0")
+#     3  prerequisite failure (jq absent / detector absent / detector error /
+#        unknown_category / gh pr lookup failed / ISSUE-PR mismatch)
+#
+#   Output JSON
+#     default path : $(mktemp -t "verify-issue-<ISSUE>.XXXXXX").json
+#     override     : $VERIFY_ISSUE_OUTPUT (absolute path)
+#     latest ptr   : ${TMPDIR:-/tmp}/verify-issue-<ISSUE>.latest.json  (symlink)
+#     schema       : inputs{requested_issue,resolved_pr,issue_pr_match,source,...}
+#                    steps[]{name,status,skip_reason,partial,...}
+#                    summary{pass_count,fail_count,skip_count,
+#                            manual_required_count,partial_count,total_count}
+#                    error{code,message,detector_stderr}  warnings[]  exit_code
+#     JSON is written even on exit-3 prereq failures EXCEPT jq_not_found
+#     (no jq → cannot build JSON; reported on stderr) and exit-2 arg errors.
+#
+#   Detector resolution
+#     ${VERIFY_ISSUE_DETECTOR:-<sibling>/verify-issue-detect.sh}
+#     detector non-zero exit  → orchestrator exit 3, error.code=detector_failed
+#     detector missing        → orchestrator exit 3, error.code=detector_failed
+#
+#   opt-in env
+#     VERIFY_REQUIRE_PR_MATCH (default 1): 0 downgrades ISSUE-PR mismatch to a
+#     warning (exit 0 if steps pass) instead of exit 3.
+#
+#   category → make target mapping (orchestrator-own derived table; SSOT is
+#   .claude/templates/issue-implementation-plan.md「🗺️ 証跡マッピング表」):
+#     backend-* / api-* / migration-safety  → make test-backend
+#     api-contract                          → + make test-frontend
+#     frontend-{ui,logic,shared}            → make test-frontend
+#     frontend-style                        → no automated step; always SKIP
+#                                             (step name frontend-style-manual,
+#                                              skip_reason manual_required)
+#     docdd                                 → make traceability
+#     dx-config                             → make shell-lint + shell-format-check
+#     dx-docs                               → make validate-claude
+#   Same make target is invoked AT MOST ONCE per run (dedup).
+#
+# 真の SSOT: .claude/templates/issue-implementation-plan.md「🗺️ 証跡マッピング表」
+
+ORCH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/verify-issue.sh"
+
+setup() {
+  TMPDIR_BATS="$(mktemp -d)"
+  BIN="$TMPDIR_BATS/bin"
+  mkdir -p "$BIN"
+  MAKE_LOG="$TMPDIR_BATS/make.log"
+  : >"$MAKE_LOG"
+
+  # ── fake make: log every invocation; fail targets listed in FAKE_MAKE_FAIL ──
+  cat >"$BIN/make" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$MAKE_LOG"
+for t in "$@"; do
+  case " ${FAKE_MAKE_FAIL:-} " in
+    *" $t "*) exit 1 ;;
+  esac
+done
+exit 0
+EOF
+  chmod +x "$BIN/make"
+
+  # ── fake gh: pr list / pr view / pr diff, controlled by FAKE_GH_* env ──
+  cat >"$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  if [ "${FAKE_GH_PR_LIST_FAIL:-0}" = "1" ]; then
+    echo "gh: could not authenticate" >&2
+    exit 1
+  fi
+  bare=0
+  for a in "$@"; do
+    [ "$a" = "--jq" ] && bare=1
+    [ "$a" = "-q" ] && bare=1
+  done
+  if [ -z "${FAKE_GH_PR_NUMBER:-}" ]; then
+    if [ "$bare" = "1" ]; then printf ''; else echo "[]"; fi
+  else
+    if [ "$bare" = "1" ]; then
+      printf '%s\n' "$FAKE_GH_PR_NUMBER"
+    else
+      printf '[{"number":%s}]\n' "$FAKE_GH_PR_NUMBER"
+    fi
+  fi
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '%s' "${FAKE_GH_PR_BODY:-}"
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "diff" ]; then
+  echo "scripts/claude/verify-issue.sh"
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$BIN/gh"
+
+  # ── fake detector: emit FAKE_DETECTOR_CATEGORIES (space-sep) one per line ──
+  cat >"$TMPDIR_BATS/detector.sh" <<'EOF'
+#!/usr/bin/env bash
+if [ "${FAKE_DETECTOR_EXIT:-0}" != "0" ]; then
+  echo "verify-issue-detect: simulated failure" >&2
+  exit "${FAKE_DETECTOR_EXIT}"
+fi
+for c in ${FAKE_DETECTOR_CATEGORIES:-}; do
+  echo "$c"
+done
+exit 0
+EOF
+  chmod +x "$TMPDIR_BATS/detector.sh"
+
+  export MAKE_LOG
+  export PATH="$BIN:$PATH"
+  export TMPDIR="$TMPDIR_BATS"
+  export VERIFY_ISSUE_OUTPUT="$TMPDIR_BATS/out.json"
+  export VERIFY_ISSUE_DETECTOR="$TMPDIR_BATS/detector.sh"
+  unset ISSUE || true
+}
+
+teardown() {
+  if [[ -n "${TMPDIR_BATS:-}" && -d "$TMPDIR_BATS" ]]; then
+    rm -rf "$TMPDIR_BATS"
+  fi
+}
+
+# ─── 1. Acceptance: 3 mandated cases (all PASS / partial FAIL / SKIP only) ───
+
+@test "acceptance: all PASS -> exit 0, fail_count 0" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Wave 5-2 orchestrator. Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="backend-unit docdd dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.summary.fail_count' "$VERIFY_ISSUE_OUTPUT")" -eq 0 ]
+  [ "$(jq -r '.summary.pass_count' "$VERIFY_ISSUE_OUTPUT")" -ge 1 ]
+}
+
+@test "acceptance: partial FAIL -> exit 1, fail_count >=1, pass_count >=1" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="backend-unit docdd"
+  export FAKE_MAKE_FAIL="traceability"
+  run "$ORCH" 62
+  [ "$status" -eq 1 ]
+  [ "$(jq -r '.summary.fail_count' "$VERIFY_ISSUE_OUTPUT")" -ge 1 ]
+  [ "$(jq -r '.summary.pass_count' "$VERIFY_ISSUE_OUTPUT")" -ge 1 ]
+}
+
+@test "acceptance: SKIP only (frontend-style) -> exit 0, skip_count >=1, pass_count 0" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="frontend-style"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.summary.skip_count' "$VERIFY_ISSUE_OUTPUT")" -ge 1 ]
+  [ "$(jq -r '.summary.pass_count' "$VERIFY_ISSUE_OUTPUT")" -eq 0 ]
+  jq -e '.steps[] | select(.name == "frontend-style-manual") | .skip_reason == "manual_required"' "$VERIFY_ISSUE_OUTPUT"
+}
+
+# ─── 2. Argument validation -> exit 2 ───────────────────────
+
+@test "argv: ISSUE missing -> exit 2" {
+  run "$ORCH"
+  [ "$status" -eq 2 ]
+}
+
+@test "argv: ISSUE=abc (non-digits) -> exit 2" {
+  run "$ORCH" abc
+  [ "$status" -eq 2 ]
+}
+
+@test "argv: ISSUE=0 -> exit 2" {
+  run "$ORCH" 0
+  [ "$status" -eq 2 ]
+}
+
+# ─── 3. Prerequisite failures -> exit 3 ─────────────────────
+
+@test "prereq: jq absent -> exit 3 + jq_not_found on stderr" {
+  cat >"$BIN/jq" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+  chmod +x "$BIN/jq"
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"jq_not_found"* ]]
+}
+
+@test "prereq: detector missing -> exit 3 + error.code detector_failed" {
+  export VERIFY_ISSUE_DETECTOR="$TMPDIR_BATS/no-such-detector.sh"
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  run "$ORCH" 62
+  [ "$status" -eq 3 ]
+  [ "$(jq -r '.error.code' "$VERIFY_ISSUE_OUTPUT")" = "detector_failed" ]
+}
+
+@test "prereq: detector exits non-zero -> exit 3 + error.code detector_failed" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_EXIT=1
+  run "$ORCH" 62
+  [ "$status" -eq 3 ]
+  [ "$(jq -r '.error.code' "$VERIFY_ISSUE_OUTPUT")" = "detector_failed" ]
+}
+
+@test "prereq: unknown category from detector -> exit 3 + error.code unknown_category" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="bogus-category"
+  run "$ORCH" 62
+  [ "$status" -eq 3 ]
+  [ "$(jq -r '.error.code' "$VERIFY_ISSUE_OUTPUT")" = "unknown_category" ]
+}
+
+# ─── 4. ISSUE-PR linkage verification ───────────────────────
+
+@test "pr-match: mismatched PR with PR_MATCH=1 -> exit 3 + pr_issue_mismatch" {
+  export FAKE_GH_PR_NUMBER=999
+  export FAKE_GH_PR_BODY="Unrelated PR title and body, no closes keyword"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 3 ]
+  [ "$(jq -r '.error.code' "$VERIFY_ISSUE_OUTPUT")" = "pr_issue_mismatch" ]
+  [ "$(jq -r '.inputs.issue_pr_match' "$VERIFY_ISSUE_OUTPUT")" = "false" ]
+  jq -e '.warnings | index("pr_issue_mismatch") != null' "$VERIFY_ISSUE_OUTPUT"
+}
+
+@test "pr-match: mismatched PR with VERIFY_REQUIRE_PR_MATCH=0 -> exit 0 + warning only" {
+  export FAKE_GH_PR_NUMBER=999
+  export FAKE_GH_PR_BODY="Unrelated PR title and body, no closes keyword"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  export VERIFY_REQUIRE_PR_MATCH=0
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.inputs.issue_pr_match' "$VERIFY_ISSUE_OUTPUT")" = "false" ]
+  jq -e '.warnings | index("pr_issue_mismatch") != null' "$VERIFY_ISSUE_OUTPUT"
+}
+
+@test "pr-match: matched PR (Closes #62) -> source pr-diff + issue_pr_match true" {
+  export FAKE_GH_PR_NUMBER=100
+  export FAKE_GH_PR_BODY="feat: orchestrator. Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.inputs.source' "$VERIFY_ISSUE_OUTPUT")" = "pr-diff" ]
+  [ "$(jq -r '.inputs.resolved_pr' "$VERIFY_ISSUE_OUTPUT")" = "100" ]
+  [ "$(jq -r '.inputs.issue_pr_match' "$VERIFY_ISSUE_OUTPUT")" = "true" ]
+}
+
+# ─── 5. PR lookup: 2-state separation (no PR vs. lookup failure) ───
+
+@test "pr-lookup: no PR (empty) -> merge-base-fallback + resolved_pr null" {
+  export FAKE_GH_PR_NUMBER=""
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.inputs.source' "$VERIFY_ISSUE_OUTPUT")" = "merge-base-fallback" ]
+  [ "$(jq -r '.inputs.resolved_pr' "$VERIFY_ISSUE_OUTPUT")" = "null" ]
+}
+
+@test "pr-lookup: gh failure -> exit 3 + error.code gh_pr_lookup_failed (no fallback)" {
+  export FAKE_GH_PR_LIST_FAIL=1
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 3 ]
+  [ "$(jq -r '.error.code' "$VERIFY_ISSUE_OUTPUT")" = "gh_pr_lookup_failed" ]
+}
+
+# ─── 6. dedup: same make target invoked at most once ────────
+
+@test "dedup: 3 categories -> test-backend, make invoked exactly once" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="backend-unit backend-integration backend-core"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  [ "$(wc -l <"$MAKE_LOG" | tr -d ' ')" -eq 1 ]
+  grep -q "test-backend" "$MAKE_LOG"
+}
+
+@test "dedup: dx-config -> both shell-lint and shell-format-check invoked" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="dx-config"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  grep -q "shell-lint" "$MAKE_LOG"
+  grep -q "shell-format-check" "$MAKE_LOG"
+}
+
+# ─── 7. stop-on-fail = CONTINUE ─────────────────────────────
+
+@test "stop-on-fail: first step fails, later steps still run + aggregated" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="backend-unit docdd"
+  export FAKE_MAKE_FAIL="test-backend"
+  run "$ORCH" 62
+  [ "$status" -eq 1 ]
+  grep -q "test-backend" "$MAKE_LOG"
+  grep -q "traceability" "$MAKE_LOG"
+  [ "$(jq -r '.summary.fail_count' "$VERIFY_ISSUE_OUTPUT")" -ge 1 ]
+  [ "$(jq -r '.summary.pass_count' "$VERIFY_ISSUE_OUTPUT")" -ge 1 ]
+}
+
+# ─── 8. JSON schema integrity ───────────────────────────────
+
+@test "schema: all required keys present" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="backend-unit docdd dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  jq -e '.inputs.requested_issue == 62' "$VERIFY_ISSUE_OUTPUT"
+  jq -e '.inputs | has("resolved_pr")' "$VERIFY_ISSUE_OUTPUT"
+  jq -e '.inputs | has("issue_pr_match")' "$VERIFY_ISSUE_OUTPUT"
+  jq -e '.inputs | has("source")' "$VERIFY_ISSUE_OUTPUT"
+  jq -e '.steps | type == "array"' "$VERIFY_ISSUE_OUTPUT"
+  jq -e '.steps[0] | has("name") and has("status")' "$VERIFY_ISSUE_OUTPUT"
+  jq -e '.summary | has("pass_count") and has("fail_count") and has("skip_count") and has("manual_required_count") and has("partial_count") and has("total_count")' "$VERIFY_ISSUE_OUTPUT"
+  jq -e 'has("error") and has("warnings") and has("exit_code")' "$VERIFY_ISSUE_OUTPUT"
+}
+
+# ─── 9. Output path override + .latest.json symlink ─────────
+
+@test "output: VERIFY_ISSUE_OUTPUT override writes to that path" {
+  export VERIFY_ISSUE_OUTPUT="$TMPDIR_BATS/custom-out.json"
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  [ -f "$TMPDIR_BATS/custom-out.json" ]
+  jq -e '.inputs.requested_issue == 62' "$TMPDIR_BATS/custom-out.json"
+}
+
+@test "output: .latest.json symlink points at the run output" {
+  export VERIFY_ISSUE_OUTPUT="$TMPDIR_BATS/custom-out.json"
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  link="$TMPDIR_BATS/verify-issue-62.latest.json"
+  [ -L "$link" ]
+  # Contract: the .latest.json symlink resolves to THIS run's output file.
+  # `-ef` (same device+inode) expresses that intent and is symlink-transparent
+  # on both macOS and Linux. The previous form string-compared
+  # `realpath "$(readlink ...)"` against the logical "$TMPDIR_BATS" path; on
+  # macOS realpath canonicalizes /var -> /private/var while $TMPDIR_BATS keeps
+  # the logical /var/folders form, so the equality could never hold there
+  # regardless of the orchestrator (tests 20 & 22 prove the symlink mechanism).
+  [ "$link" -ef "$VERIFY_ISSUE_OUTPUT" ]
+}
+
+@test "output: default path used when VERIFY_ISSUE_OUTPUT unset + latest symlink" {
+  unset VERIFY_ISSUE_OUTPUT
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  link="$TMPDIR_BATS/verify-issue-62.latest.json"
+  [ -L "$link" ]
+  jq -e '.inputs.requested_issue == 62' "$link"
+}
+
+# ─── 10. stdout summary echo (CI log readability) ───────────
+
+@test "summary-echo: PASS run ends with the SubsCore-style PASSED line" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"verify-issue #62 PASSED"* ]]
+}
+
+@test "summary-echo: FAIL run ends with the SubsCore-style FAILED line" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  export FAKE_MAKE_FAIL="validate-claude"
+  run "$ORCH" 62
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"verify-issue #62 FAILED"* ]]
+}
+
+# ─── 11. ISSUE via env when positional arg absent ───────────
+
+@test "argv: ISSUE env used when positional arg absent" {
+  export ISSUE=62
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.inputs.requested_issue' "$VERIFY_ISSUE_OUTPUT")" -eq 62 ]
+}

--- a/scripts/claude/test/verify-issue.bats
+++ b/scripts/claude/test/verify-issue.bats
@@ -45,12 +45,18 @@
 #     api-contract                          → + make test-frontend
 #     frontend-{ui,logic,shared}            → make test-frontend
 #     frontend-style                        → no automated step; always SKIP
-#                                             (step name frontend-style-manual,
-#                                              skip_reason manual_required)
 #     docdd                                 → make traceability
 #     dx-config                             → make shell-lint + shell-format-check
 #     dx-docs                               → make validate-claude
 #   Same make target is invoked AT MOST ONCE per run (dedup).
+#
+#   Manual-required placeholders (ADDITIVE to automated steps): every detected
+#   category whose SSOT mapping requires manual evidence also emits a separate
+#   skip step named <category>-manual (skip_reason manual_required, command
+#   null), counted in summary.manual_required_count. Applies to api-route,
+#   api-contract, backend-core, frontend-ui, frontend-style, docdd, dx-config,
+#   dx-docs. migration-safety is the lone exception: its manual aspect is the
+#   partial+notes flag on test-backend, NOT a separate placeholder.
 #
 # 真の SSOT: .claude/templates/issue-implementation-plan.md「🗺️ 証跡マッピング表」
 
@@ -418,4 +424,63 @@ EOF
   run "$ORCH"
   [ "$status" -eq 0 ]
   [ "$(jq -r '.inputs.requested_issue' "$VERIFY_ISSUE_OUTPUT")" -eq 62 ]
+}
+
+# ─── 12. manual_required placeholders are additive to automated steps ───
+# A category that also has an automated make target must STILL emit a
+# <category>-manual skip step so 5-3 surfaces pending manual evidence even
+# when the automated target passes (exit 0).
+
+@test "manual: backend-core passes automated step AND emits backend-core-manual" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="backend-core"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  grep -q "test-backend" "$MAKE_LOG"
+  [ "$(jq -r '.summary.pass_count' "$VERIFY_ISSUE_OUTPUT")" -ge 1 ]
+  jq -e '.steps[] | select(.name == "backend-core-manual") | .status == "skip" and .skip_reason == "manual_required" and .command == null' "$VERIFY_ISSUE_OUTPUT"
+  [ "$(jq -r '.summary.manual_required_count' "$VERIFY_ISSUE_OUTPUT")" -ge 1 ]
+}
+
+@test "manual: manual_required_count counts every manual-bearing category" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="api-route dx-docs"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  jq -e '.steps[] | select(.name == "api-route-manual") | .skip_reason == "manual_required"' "$VERIFY_ISSUE_OUTPUT"
+  jq -e '.steps[] | select(.name == "dx-docs-manual") | .skip_reason == "manual_required"' "$VERIFY_ISSUE_OUTPUT"
+  [ "$(jq -r '.summary.manual_required_count' "$VERIFY_ISSUE_OUTPUT")" -eq 2 ]
+}
+
+@test "manual: migration-safety does NOT emit a separate manual placeholder (partial only)" {
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="migration-safety"
+  run "$ORCH" 62
+  [ "$status" -eq 0 ]
+  jq -e '[.steps[] | select(.name == "migration-safety-manual")] | length == 0' "$VERIFY_ISSUE_OUTPUT"
+  jq -e '.steps[] | select(.name == "test-backend") | .partial == true' "$VERIFY_ISSUE_OUTPUT"
+}
+
+# ─── 13. result-JSON write failure must fail loudly (Codex /review P2) ───
+# The result JSON is the contract 5-3 consumes. An unwritable
+# VERIFY_ISSUE_OUTPUT location must yield exit 3 (not a PASSED echo with the
+# original success code) so downstream never trusts a stale/absent file.
+# Assumes the suite runs as a NON-root user: root bypasses the read-only dir;
+# both GH Actions runners and local macOS dev run non-root.
+
+@test "output: unwritable VERIFY_ISSUE_OUTPUT -> exit 3, not PASSED" {
+  mkdir -p "$TMPDIR_BATS/ro"
+  chmod 500 "$TMPDIR_BATS/ro"
+  export VERIFY_ISSUE_OUTPUT="$TMPDIR_BATS/ro/out.json"
+  export FAKE_GH_PR_NUMBER=62
+  export FAKE_GH_PR_BODY="Closes #62"
+  export FAKE_DETECTOR_CATEGORIES="dx-docs"
+  run "$ORCH" 62
+  chmod 700 "$TMPDIR_BATS/ro"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"output_write_failed"* ]]
+  [[ "$output" != *"PASSED"* ]]
 }

--- a/scripts/claude/verify-issue.sh
+++ b/scripts/claude/verify-issue.sh
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+# scripts/claude/verify-issue.sh
+#
+# Wave 5-2 orchestrator: `make verify-issue ISSUE=<N>` runs 6 steps serially:
+#   0. prerequisite check (jq)
+#   1. Issue -> PR resolution + ISSUE-PR linkage verification
+#   2. change-aware category detection (delegates to verify-issue-detect.sh, 5-1)
+#   3. per-category verification execution (deduped make targets)
+#   4. result aggregation (PASS / FAIL / SKIP, 5 summary stats)
+#   5. structured JSON output (contract for Wave 5-3) + .latest.json symlink
+#   6. exit code (0 pass / 1 fail / 2 arg invalid / 3 prerequisite failure)
+#
+# SubsCore-style positional model: verify-issue.sh <ISSUE> [args]
+# ISSUE env is used when the positional arg is absent.
+#
+# JSON safety: built with `jq -n --arg/--argjson` only (never string concat).
+# Step stdout/stderr bodies are spooled to side files; JSON stores paths only.
+#
+# 真の SSOT (category mapping): .claude/templates/issue-implementation-plan.md
+#   「🗺️ 証跡マッピング表」. The category -> make-target table below is an
+#   orchestrator-own derived table that follows it (never the reverse).
+# JSON schema SSOT: .claude/templates/verify-issue-result.json (5-3 contract).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOGDIR="${TMPDIR:-/tmp}"
+
+# Capture the inherited ISSUE env BEFORE the globals block resets it, so the
+# `ISSUE=<N> make verify-issue` form (no positional arg) keeps working.
+ENV_ISSUE="${ISSUE:-}"
+
+# ─── State (globals; orchestrator has no -e so failing steps don't abort) ───
+ISSUE=""
+PID="$$"
+RUN_ID=""
+STARTED_AT=""
+OUTPUT_PATH=""
+ABS_OUTPUT=""
+LATEST=""
+STEPS_FILE=""
+SOURCE_VAL=""
+RESOLVED_PR=""
+ISSUE_PR_MATCH="false"
+WARNINGS_JSON="[]"
+ERR_CODE=""
+ERR_MSG=""
+ERR_DETECTOR_STDERR=""
+DETECTED=""
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+MANUAL_REQUIRED_COUNT=0
+PARTIAL_COUNT=0
+TOTAL_COUNT=0
+
+now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+in_list() {
+  local needle="$1" hay=" $2 "
+  [[ "$hay" == *" $needle "* ]]
+}
+
+# Emit a JSON array of strings from a space-separated list (empty -> []).
+csv_to_json_array() {
+  local s="$1"
+  if [[ -z "$s" ]]; then
+    printf '[]'
+    return
+  fi
+  local arr
+  read -ra arr <<<"$s"
+  printf '%s\n' "${arr[@]}" | jq -R . | jq -sc .
+}
+
+add_warning() {
+  WARNINGS_JSON="$(printf '%s' "$WARNINGS_JSON" | jq -c --arg w "$1" '. + [$w]')"
+}
+
+known_category() {
+  case "$1" in
+    backend-unit | backend-integration | api-route | api-contract | backend-core | migration-safety)
+      return 0
+      ;;
+    frontend-ui | frontend-logic | frontend-shared | frontend-style)
+      return 0
+      ;;
+    docdd | dx-config | dx-docs)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+append_step() {
+  local name="$1" command="$2" status="$3" exit_code="$4" so="$5" se="$6"
+  local skip_reason="$7" partial="$8" notes="$9" cats_json="${10}"
+  local started="${11}" finished="${12}"
+  jq -nc \
+    --arg name "$name" \
+    --arg command "$command" \
+    --arg status "$status" \
+    --argjson exit_code "$exit_code" \
+    --arg so "$so" \
+    --arg se "$se" \
+    --arg skip_reason "$skip_reason" \
+    --argjson partial "$partial" \
+    --arg notes "$notes" \
+    --argjson categories "$cats_json" \
+    --arg started "$started" \
+    --arg finished "$finished" \
+    '{
+      name: $name,
+      categories: $categories,
+      command: (if $command == "" then null else $command end),
+      status: $status,
+      exit_code: $exit_code,
+      stdout_path: (if $so == "" then null else $so end),
+      stderr_path: (if $se == "" then null else $se end),
+      skip_reason: (if $skip_reason == "" then null else $skip_reason end),
+      partial: $partial,
+      notes: (if $notes == "" then null else $notes end),
+      started_at: $started,
+      finished_at: $finished
+    }' >>"$STEPS_FILE"
+}
+
+# Write the result JSON atomically, refresh the .latest.json symlink, echo the
+# SubsCore-style summary line, and exit. Used for both success and (most)
+# prerequisite failures. NOT used for arg errors (exit 2) or jq_not_found.
+finish() {
+  local code="$1"
+  local steps_json resolved_pr_json source_json error_json finished_at
+  if [[ -s "$STEPS_FILE" ]]; then
+    steps_json="$(jq -sc . "$STEPS_FILE")"
+  else
+    steps_json='[]'
+  fi
+  if [[ -n "$RESOLVED_PR" ]]; then
+    resolved_pr_json="$RESOLVED_PR"
+  else
+    resolved_pr_json='null'
+  fi
+  source_json="$(jq -nc --arg s "$SOURCE_VAL" 'if $s == "" then null else $s end')"
+  error_json="$(jq -nc \
+    --arg c "$ERR_CODE" --arg m "$ERR_MSG" --arg d "$ERR_DETECTOR_STDERR" \
+    '{
+      code: (if $c == "" then null else $c end),
+      message: (if $m == "" then null else $m end),
+      detector_stderr: (if $d == "" then null else $d end)
+    }')"
+  finished_at="$(now)"
+
+  mkdir -p "$(dirname "$ABS_OUTPUT")"
+  jq -n \
+    --argjson requested_issue "$ISSUE" \
+    --argjson resolved_pr "$resolved_pr_json" \
+    --argjson issue_pr_match "$ISSUE_PR_MATCH" \
+    --argjson source "$source_json" \
+    --arg run_id "$RUN_ID" \
+    --argjson pid "$PID" \
+    --arg output_path "$ABS_OUTPUT" \
+    --arg started_at "$STARTED_AT" \
+    --arg finished_at "$finished_at" \
+    --argjson steps "$steps_json" \
+    --argjson pass_count "$PASS_COUNT" \
+    --argjson fail_count "$FAIL_COUNT" \
+    --argjson skip_count "$SKIP_COUNT" \
+    --argjson manual_required_count "$MANUAL_REQUIRED_COUNT" \
+    --argjson partial_count "$PARTIAL_COUNT" \
+    --argjson total_count "$TOTAL_COUNT" \
+    --argjson error "$error_json" \
+    --argjson warnings "$WARNINGS_JSON" \
+    --argjson exit_code "$code" \
+    '{
+      inputs: {
+        requested_issue: $requested_issue,
+        resolved_pr: $resolved_pr,
+        issue_pr_match: $issue_pr_match,
+        source: $source,
+        run_id: $run_id,
+        pid: $pid,
+        output_path: $output_path,
+        started_at: $started_at,
+        finished_at: $finished_at
+      },
+      steps: $steps,
+      summary: {
+        pass_count: $pass_count,
+        fail_count: $fail_count,
+        skip_count: $skip_count,
+        manual_required_count: $manual_required_count,
+        partial_count: $partial_count,
+        total_count: $total_count
+      },
+      error: $error,
+      warnings: $warnings,
+      exit_code: $exit_code
+    }' >"${ABS_OUTPUT}.tmp.${PID}"
+  mv -f "${ABS_OUTPUT}.tmp.${PID}" "$ABS_OUTPUT"
+  ln -sf "$ABS_OUTPUT" "$LATEST"
+
+  if [[ "$code" -eq 0 ]]; then
+    printf '✅ verify-issue #%s PASSED (pass=%s skip=%s)\n' \
+      "$ISSUE" "$PASS_COUNT" "$SKIP_COUNT"
+  else
+    printf '❌ verify-issue #%s FAILED (fail=%s pass=%s skip=%s)\n' \
+      "$ISSUE" "$FAIL_COUNT" "$PASS_COUNT" "$SKIP_COUNT"
+  fi
+  exit "$code"
+}
+
+# ─── Step 0: argument validation (exit 2, no JSON) ───
+issue_arg="${1:-}"
+if [[ -n "$issue_arg" ]]; then
+  shift
+fi
+# Forward-compat: remaining positionals are reserved for future opt-in flags
+# (e.g. --stop-on-first-fail). SubsCore EXTRA_ARGS parity.
+# shellcheck disable=SC2034
+EXTRA_ARGS=("$@")
+
+ISSUE="${issue_arg:-$ENV_ISSUE}"
+if [[ -z "$ISSUE" ]]; then
+  printf 'ERROR: ISSUE required (usage: verify-issue.sh <ISSUE> | ISSUE=<N> make verify-issue)\n' >&2
+  exit 2
+fi
+if [[ ! "$ISSUE" =~ ^[0-9]+$ ]]; then
+  printf 'ERROR: ISSUE must be digits-only (got: %s)\n' "$ISSUE" >&2
+  exit 2
+fi
+if [[ "$ISSUE" -eq 0 ]]; then
+  printf 'ERROR: ISSUE must be a positive integer (got: 0)\n' >&2
+  exit 2
+fi
+
+# ─── Step 0: prerequisite — jq (exit 3, no JSON: cannot build it without jq) ───
+if ! jq --version >/dev/null 2>&1; then
+  printf 'ERROR: jq_not_found — jq is required to build the result JSON; install jq and retry\n' >&2
+  exit 3
+fi
+
+RUN_ID="${PID}-$(date -u +%s)"
+STARTED_AT="$(now)"
+STEPS_FILE="${LOGDIR}/verify-issue-${ISSUE}.${PID}.steps.ndjson"
+: >"$STEPS_FILE"
+
+# Resolve output path (env override > mktemp default) + absolute + latest ptr.
+if [[ -n "${VERIFY_ISSUE_OUTPUT:-}" ]]; then
+  OUTPUT_PATH="$VERIFY_ISSUE_OUTPUT"
+else
+  _base="$(mktemp "${LOGDIR}/verify-issue-${ISSUE}.XXXXXX")"
+  OUTPUT_PATH="${_base}.json"
+  rm -f "$_base"
+fi
+_odir="$(dirname "$OUTPUT_PATH")"
+mkdir -p "$_odir"
+ABS_OUTPUT="$(cd "$_odir" && pwd)/$(basename "$OUTPUT_PATH")"
+LATEST="${LOGDIR}/verify-issue-${ISSUE}.latest.json"
+
+# ─── Step 1: Issue -> PR resolution (2-state separation) ───
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+gh_err="${LOGDIR}/verify-issue-${ISSUE}.${PID}.gh.stderr"
+pr_raw="$(gh pr list --head "$branch" --state all --json number --jq '.[0].number' 2>"$gh_err")"
+gh_rc=$?
+if [[ "$gh_rc" -ne 0 ]]; then
+  ERR_CODE="gh_pr_lookup_failed"
+  ERR_MSG="gh pr list failed (rc=${gh_rc}); not falling back (cannot confirm PR)"
+  finish 3
+fi
+
+pr_num="$(printf '%s' "$pr_raw" | tr -d '[:space:]')"
+if [[ "$pr_num" == "null" ]]; then
+  pr_num=""
+fi
+
+if [[ -z "$pr_num" ]]; then
+  # PR not created yet (normal): use detector --git merge-base fallback.
+  SOURCE_VAL="merge-base-fallback"
+  RESOLVED_PR=""
+  ISSUE_PR_MATCH="false"
+else
+  SOURCE_VAL="pr-diff"
+  RESOLVED_PR="$pr_num"
+  pr_text="$(gh pr view "$pr_num" --json body,title -q '.body + " " + .title' 2>/dev/null || true)"
+  if printf '%s' "$pr_text" | grep -Eq "#${ISSUE}([^0-9]|$)"; then
+    ISSUE_PR_MATCH="true"
+  else
+    ISSUE_PR_MATCH="false"
+    add_warning "pr_issue_mismatch"
+    if [[ "${VERIFY_REQUIRE_PR_MATCH:-1}" != "0" ]]; then
+      ERR_CODE="pr_issue_mismatch"
+      ERR_MSG="PR #${pr_num} body/title does not reference #${ISSUE} (set VERIFY_REQUIRE_PR_MATCH=0 to downgrade to warning)"
+      finish 3
+    fi
+  fi
+fi
+
+# ─── Step 2: change-aware category detection (delegate to 5-1 detector) ───
+DETECTOR="${VERIFY_ISSUE_DETECTOR:-${SCRIPT_DIR}/verify-issue-detect.sh}"
+det_err="${LOGDIR}/verify-issue-${ISSUE}.${PID}.detector.stderr"
+if [[ ! -e "$DETECTOR" ]]; then
+  ERR_CODE="detector_failed"
+  ERR_MSG="detector not found: ${DETECTOR}"
+  finish 3
+fi
+
+if [[ "$SOURCE_VAL" == "pr-diff" ]]; then
+  det_out="$(gh pr diff "$RESOLVED_PR" --name-only 2>/dev/null | "$DETECTOR" --stdin --format flat 2>"$det_err")"
+  det_rc=$?
+else
+  det_out="$("$DETECTOR" --git --format flat 2>"$det_err")"
+  det_rc=$?
+fi
+if [[ "$det_rc" -ne 0 ]]; then
+  ERR_CODE="detector_failed"
+  ERR_MSG="verify-issue-detect.sh exited ${det_rc}"
+  if [[ -s "$det_err" ]]; then
+    ERR_DETECTOR_STDERR="$(cat "$det_err")"
+  fi
+  finish 3
+fi
+
+# Dedup categories, preserving first-seen order.
+while IFS= read -r line; do
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  [[ -z "$line" ]] && continue
+  if ! in_list "$line" "$DETECTED"; then
+    DETECTED="${DETECTED:+$DETECTED }$line"
+  fi
+done <<<"$det_out"
+
+# Reject any category the orchestrator's derived table does not know.
+if [[ -n "$DETECTED" ]]; then
+  read -ra _cats <<<"$DETECTED"
+  for c in "${_cats[@]}"; do
+    if ! known_category "$c"; then
+      ERR_CODE="unknown_category"
+      ERR_MSG="detector emitted an unknown category: ${c}"
+      finish 3
+    fi
+  done
+fi
+
+# ─── Step 3-4: per-category verification (deduped make targets) + aggregate ───
+run_make_step() {
+  local name="$1" target="$2" cats="$3" partial="$4" notes="$5"
+  local started so se rc finished status cats_json
+  started="$(now)"
+  so="${LOGDIR}/verify-issue-${ISSUE}.${PID}.${name}.stdout"
+  se="${LOGDIR}/verify-issue-${ISSUE}.${PID}.${name}.stderr"
+  if make "$target" >"$so" 2>"$se"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  finished="$(now)"
+  if [[ "$rc" -eq 0 ]]; then
+    status="pass"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    status="fail"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+  if [[ "$partial" == "true" ]]; then
+    PARTIAL_COUNT=$((PARTIAL_COUNT + 1))
+  fi
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  cats_json="$(csv_to_json_array "$cats")"
+  append_step "$name" "make $target" "$status" "$rc" "$so" "$se" \
+    "" "$partial" "$notes" "$cats_json" "$started" "$finished"
+}
+
+maybe_step() {
+  local name="$1" target="$2" triggers="$3"
+  local matched="" t partial="false" notes=""
+  local trig_arr
+  read -ra trig_arr <<<"$triggers"
+  for t in "${trig_arr[@]}"; do
+    if in_list "$t" "$DETECTED"; then
+      matched="${matched:+$matched }$t"
+    fi
+  done
+  [[ -z "$matched" ]] && return 0
+  if [[ "$name" == "test-backend" ]] && in_list "migration-safety" "$matched"; then
+    partial="true"
+    notes="up/down not validated (migration-safety: CI-only scope)"
+  fi
+  run_make_step "$name" "$target" "$matched" "$partial" "$notes"
+}
+
+maybe_manual() {
+  local name="$1" trigger="$2"
+  in_list "$trigger" "$DETECTED" || return 0
+  local started cats_json
+  started="$(now)"
+  cats_json="$(csv_to_json_array "$trigger")"
+  SKIP_COUNT=$((SKIP_COUNT + 1))
+  MANUAL_REQUIRED_COUNT=$((MANUAL_REQUIRED_COUNT + 1))
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  append_step "$name" "" "skip" "null" "" "" \
+    "manual_required" "false" "" "$cats_json" "$started" "$(now)"
+}
+
+# Canonical order. One step per unique make target => dedup is structural
+# (e.g. backend-unit + backend-integration + backend-core all share one
+# `make test-backend` invocation).
+maybe_step "test-backend" "test-backend" \
+  "backend-unit backend-integration api-route api-contract backend-core migration-safety"
+maybe_step "test-frontend" "test-frontend" \
+  "api-contract frontend-ui frontend-logic frontend-shared"
+maybe_step "traceability" "traceability" "docdd"
+maybe_step "shell-lint" "shell-lint" "dx-config"
+maybe_step "shell-format-check" "shell-format-check" "dx-config"
+maybe_step "validate-claude" "validate-claude" "dx-docs"
+maybe_manual "frontend-style-manual" "frontend-style"
+
+# ─── Step 5-6: exit code + structured JSON output ───
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+  finish 1
+fi
+finish 0

--- a/scripts/claude/verify-issue.sh
+++ b/scripts/claude/verify-issue.sh
@@ -132,7 +132,7 @@ append_step() {
 # prerequisite failures. NOT used for arg errors (exit 2) or jq_not_found.
 finish() {
   local code="$1"
-  local steps_json resolved_pr_json source_json error_json finished_at
+  local steps_json resolved_pr_json source_json error_json finished_at write_rc
   if [[ -s "$STEPS_FILE" ]]; then
     steps_json="$(jq -sc . "$STEPS_FILE")"
   else
@@ -153,7 +153,7 @@ finish() {
     }')"
   finished_at="$(now)"
 
-  mkdir -p "$(dirname "$ABS_OUTPUT")"
+  mkdir -p "$(dirname "$ABS_OUTPUT")" 2>/dev/null || true
   jq -n \
     --argjson requested_issue "$ISSUE" \
     --argjson resolved_pr "$resolved_pr_json" \
@@ -198,9 +198,20 @@ finish() {
       error: $error,
       warnings: $warnings,
       exit_code: $exit_code
-    }' >"${ABS_OUTPUT}.tmp.${PID}"
-  mv -f "${ABS_OUTPUT}.tmp.${PID}" "$ABS_OUTPUT"
-  ln -sf "$ABS_OUTPUT" "$LATEST"
+    }' >"${ABS_OUTPUT}.tmp.${PID}" 2>/dev/null
+  write_rc=$?
+  # The structured JSON is the contract 5-3 consumes. If it cannot be written
+  # (unwritable VERIFY_ISSUE_OUTPUT / invalid TMPDIR / jq build failure), the
+  # run must fail loudly instead of echoing PASSED with the original code —
+  # otherwise downstream reads a stale/absent file and trusts a false "verified".
+  if [[ "$write_rc" -ne 0 ]] || ! mv -f "${ABS_OUTPUT}.tmp.${PID}" "$ABS_OUTPUT" 2>/dev/null; then
+    rm -f "${ABS_OUTPUT}.tmp.${PID}" 2>/dev/null || true
+    printf 'ERROR: output_write_failed — could not write result JSON to %s\n' \
+      "$ABS_OUTPUT" >&2
+    exit 3
+  fi
+  ln -sf "$ABS_OUTPUT" "$LATEST" 2>/dev/null \
+    || printf 'WARN: could not update latest symlink %s\n' "$LATEST" >&2
 
   if [[ "$code" -eq 0 ]]; then
     printf '✅ verify-issue #%s PASSED (pass=%s skip=%s)\n' \
@@ -392,8 +403,15 @@ maybe_step() {
   run_make_step "$name" "$target" "$matched" "$partial" "$notes"
 }
 
+# Emit a manual_required placeholder step for a detected category. This is
+# additive to (not a replacement for) the automated step: 5-3 reads these
+# placeholders to surface "manual evidence still pending" so a PR whose
+# automated targets all pass is NOT reported as fully verified. SSOT for which
+# categories require manual evidence: .claude/templates/issue-implementation-plan.md
+# 「🗺️ 証跡マッピング表」 manual_steps column (migration-safety is the lone
+# exception: its manual aspect is the partial+notes flag on test-backend).
 maybe_manual() {
-  local name="$1" trigger="$2"
+  local name="$1" trigger="$2" notes="${3:-}"
   in_list "$trigger" "$DETECTED" || return 0
   local started cats_json
   started="$(now)"
@@ -402,7 +420,7 @@ maybe_manual() {
   MANUAL_REQUIRED_COUNT=$((MANUAL_REQUIRED_COUNT + 1))
   TOTAL_COUNT=$((TOTAL_COUNT + 1))
   append_step "$name" "" "skip" "null" "" "" \
-    "manual_required" "false" "" "$cats_json" "$started" "$(now)"
+    "manual_required" "false" "$notes" "$cats_json" "$started" "$(now)"
 }
 
 # Canonical order. One step per unique make target => dedup is structural
@@ -416,7 +434,26 @@ maybe_step "traceability" "traceability" "docdd"
 maybe_step "shell-lint" "shell-lint" "dx-config"
 maybe_step "shell-format-check" "shell-format-check" "dx-config"
 maybe_step "validate-claude" "validate-claude" "dx-docs"
-maybe_manual "frontend-style-manual" "frontend-style"
+
+# Manual-required placeholders for every detected category whose SSOT mapping
+# requires manual evidence (canonical order). migration-safety is intentionally
+# absent: its manual aspect is recorded as partial+notes on test-backend.
+maybe_manual "api-route-manual" "api-route" \
+  "6_API yaml updated + all callers reviewed (manual)"
+maybe_manual "api-contract-manual" "api-contract" \
+  "Frontend type parity visual check (mandatory)"
+maybe_manual "backend-core-manual" "backend-core" \
+  "Behavior check (manual)"
+maybe_manual "frontend-ui-manual" "frontend-ui" \
+  "Browser visual check"
+maybe_manual "frontend-style-manual" "frontend-style" \
+  "Browser visual check (mandatory)"
+maybe_manual "docdd-manual" "docdd" \
+  "frontmatter visual check"
+maybe_manual "dx-config-manual" "dx-config" \
+  "Behavior check + existing tests non-regression (manual)"
+maybe_manual "dx-docs-manual" "dx-docs" \
+  "Visual check"
 
 # ─── Step 5-6: exit code + structured JSON output ───
 if [[ "$FAIL_COUNT" -gt 0 ]]; then


### PR DESCRIPTION
## 変更内容

- Wave 5-2: `make verify-issue` 6 ステップ統合 orchestrator を新規追加（DX レイヤー）。`scripts/claude/verify-issue.sh`（Step 0-6: 入力固定 → detect → カテゴリ別品質ゲート → 集約 → 結果 JSON 出力）+ `make verify-issue` / `make verify-issue-fixture` ターゲット。
- Wave 5-1 の `verify-issue-detect.sh`（detector）を呼び出し、検出カテゴリごとに automated / manual ステップを集計して `.claude/templates/verify-issue-result.json` 形式で出力。`.latest.json` symlink は best-effort（WARN のみ、JSON 本体が一次契約）。
- 結果 JSON 書込失敗（`jq` rc / `mv` 失敗 / 書込不可 `VERIFY_ISSUE_OUTPUT`）を検知して **exit 3**（前提失敗 regime）で停止。silent な偽 PASSED を防止。
- manual placeholder を手動証跡を要する全カテゴリ（api-route / api-contract / backend-core / frontend-ui / docdd / dx-config / dx-docs）に加算（migration-safety は partial+notes 維持で例外）。
- bats fixture 29 ケース（5-1 detector baseline 43 ケース完全非破壊を含む）+ `scripts/claude/README.md` を同時整合。既存 make ターゲットは未改変。

## テスト

- [x] `make test-backend` / `make test-frontend` / `make test` — N/A（DX tooling のみ。backend/frontend コード変更なし）
- [x] `make validate-claude` — PASS（20 passed / 0 failed / 20 warnings は baseline 許容）
- [x] `make traceability` — PASS（DocDD 7-axis 文書の変更なし、baseline 非破壊）
- [x] 追加ゲート — `make shell-lint` PASS / `make shell-format-check` PASS / `make verify-issue-fixture` PASS（29 ok / 0 not ok）/ `make verify-issue-detect` PASS（43 ok / 0 not ok、5-1 baseline 非破壊）/ `make test-hooks` PASS（9 ok / 0 not ok）/ dogfooding `make verify-issue ISSUE=62` PASS（exit 0）
- [x] ブラウザヘルスチェック — N/A（ブラウザ導線なし）

## 関連

Closes #62
