### PR TITLE
feat(harness): wire validator strict mode + harness regression suite (#67)

### DIFF
--- a/.claude/skills/backend-patterns/SKILL.md
+++ b/.claude/skills/backend-patterns/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: backend-patterns
+description: |
+  FastAPI モジュラーモノリスのバックエンド実装パターン。
+  API 設計（レイヤー分離）、DDD パターン（Entity / Repository / Service）、
+  依存性注入、エラーハンドリング、ミドルウェア、pytest テスト戦略を提供。
+  バックエンド実装時（`/develop` 等）に参照される。
+---
+
 # Backend Patterns - FastAPI モジュラーモノリス
 
 ## 概要

--- a/.claude/skills/docdd-workflow/SKILL.md
+++ b/.claude/skills/docdd-workflow/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: docdd-workflow
+description: |
+  DocDD（Doc Driven Development）7軸トレーサビリティの運用ルール。
+  BR→UC→DM→SR/NSR→EXT→API→TC の追跡構造、frontmatter 規約、
+  traceability map 検証の運用を提供。DocDD ドキュメント更新時に参照される。
+---
+
 # DocDD Workflow - 7軸トレーサビリティ運用スキル
 
 ## 概要

--- a/.claude/skills/frontend-patterns/SKILL.md
+++ b/.claude/skills/frontend-patterns/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: frontend-patterns
+description: |
+  Next.js App Router のフロントエンド実装パターン。
+  データフェッチ（Server Components / Colocation）、Container/Presentational、
+  キャッシュ・レンダリング戦略、Private Folder、認証・エラーハンドリングを提供。
+  フロントエンド実装時（`/develop` 等）に参照される。
+---
+
 # Frontend Patterns - Next.js App Router
 
 ## 概要

--- a/.claude/skills/testing-patterns/SKILL.md
+++ b/.claude/skills/testing-patterns/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: testing-patterns
+description: |
+  pytest（バックエンド）/ Vitest（フロントエンド）のテスト戦略。
+  Unit / Integration / E2E のテスト分類、ディレクトリ構造、フィクスチャ、
+  CI 戦略を提供。テスト追加・修正時（`/develop` `/tdd` `/verify`）に参照される。
+---
+
 # Testing Patterns - テスト戦略
 
 ## 概要

--- a/.github/workflows/docdd-starters-ci.yml
+++ b/.github/workflows/docdd-starters-ci.yml
@@ -46,6 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
       - name: Install shfmt
         run: |
           curl -sS https://webi.sh/shfmt | sh
@@ -54,12 +57,16 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq bats
+      - name: Install jq
+        run: sudo apt-get install -y -qq jq
       - name: shellcheck
         run: make shell-lint
       - name: shfmt
         run: make shell-format-check
       - name: bats
         run: make test-hooks
+      - name: Harness regression
+        run: make test-harness
 
   docdd-validation:
     runs-on: ubuntu-latest
@@ -72,6 +79,8 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
       - name: Validate Claude config
         run: make validate-claude
+      - name: Validate Claude config (strict)
+        run: make validate-claude-strict
       - name: Validate traceability
         run: make traceability
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 .PHONY: tf-init tf-plan tf-apply tf-destroy tf-output
 .PHONY: deploy-backend-stg deploy-frontend-stg deploy-stg deploy-backend-prod deploy-frontend-prod deploy-prod
 .PHONY: ecs-status ecs-logs-backend ecs-logs-frontend ecs-sh
-.PHONY: shell-lint shell-format-check test-hooks verify-issue-detect verify-issue verify-issue-fixture
-.PHONY: validate-claude
+.PHONY: shell-lint shell-format-check test-hooks verify-issue-detect verify-issue verify-issue-fixture test-harness
+.PHONY: validate-claude validate-claude-strict
 
 PYTHON ?= python3
 
@@ -31,6 +31,12 @@ traceability:
 
 validate-claude:
 	./scripts/claude/validate-claude-config.sh
+
+# strict mode: warnings (missing frontmatter etc.) are promoted to failures.
+# CI safety-net (backstop); local proof paths intentionally stay on baseline
+# (see scripts/claude/README.md "strict モード運用").
+validate-claude-strict:
+	./scripts/claude/validate-claude-config.sh --strict
 
 test-backend:
 	PYTHONPATH=apps/backend pytest tests/backend
@@ -108,6 +114,18 @@ verify-issue-fixture:
 		exit 1; \
 	else \
 		echo "WARN: bats not found, skipping verify-issue-fixture"; \
+	fi
+
+# Harness regression suite: asserts .claude/ configuration invariants
+# (frontmatter strict, settings.json shape, hook bindings, terminology drift).
+test-harness:
+	@if command -v bats >/dev/null 2>&1; then \
+		bats scripts/claude/test/harness-regression.bats; \
+	elif [ "$$CI" = "true" ] || [ "$$HARNESS_REQUIRE_BATS" = "1" ]; then \
+		echo "ERROR: bats not found (required when CI=true or HARNESS_REQUIRE_BATS=1)"; \
+		exit 1; \
+	else \
+		echo "WARN: bats not found, skipping test-harness"; \
 	fi
 
 # ─── Terraform ───────────────────────────────────────────

--- a/scripts/claude/README.md
+++ b/scripts/claude/README.md
@@ -29,13 +29,14 @@ Claude Code / DocDD ワークフローを支えるスクリプト群。
 | ファイル | 役割 | 呼び出し元 |
 |---------|------|-----------|
 | `detect-capabilities.sh` | gh / codex / pencil / aws 等の利用可否を JSON で出力 | `scripts/bootstrap.sh` |
-| `validate-claude-config.sh` | `.claude/` 配下の構成・命名・frontmatter を検証 | `make validate-claude` |
-| `validate_claude_frontmatter.py` | skill / command の frontmatter スキーマ検証 | `validate-claude-config.sh` 内部 |
+| `validate-claude-config.sh` | `.claude/` 配下の構成・命名・frontmatter を検証（baseline / `--strict`） | `make validate-claude`、`make validate-claude-strict` |
+| `validate_claude_frontmatter.py` | skill / command の frontmatter スキーマ検証（`--strict` / `--dir`） | `validate-claude-config.sh` 内部 |
 | `verify-issue-detect.sh` | 変更パスから必要証跡カテゴリを列挙する change-aware detector | `make verify-issue-detect`、`verify-issue.sh`（5-2）、5-3（後続 Issue） |
 | `verify-issue.sh` | Issue 番号 → PR 解決 → detector → カテゴリ別検証 → 構造化 JSON 出力の 6 ステップ orchestrator | `make verify-issue`、5-3（後続 Issue） |
 | `test-hooks.bats` | `.claude/hooks/` の bats fixture | `make test-hooks` |
 | `test/verify-issue-detect.bats` | `verify-issue-detect.sh` の bats fixture | `make verify-issue-detect` |
 | `test/verify-issue.bats` | `verify-issue.sh` の bats fixture（29 ケース） | `make verify-issue-fixture` |
+| `test/harness-regression.bats` | `.claude/` harness 不変条件の回帰スイート（V6 カタログ 1〜10） | `make test-harness` |
 
 ---
 
@@ -168,10 +169,84 @@ make verify-issue ISSUE=62
 
 ---
 
+## validate-claude-config.sh — strict モード / harness 回帰スイート（Wave 6-1）
+
+### strict モード運用
+
+`validate-claude-config.sh` は 2 モードで動作する。
+
+| モード | 起動 | 挙動 | exit |
+|--------|------|------|:----:|
+| baseline（既定） | `make validate-claude` | frontmatter 欠落 = warning | warning があっても 0 |
+| strict | `make validate-claude-strict`（`validate-claude-config.sh --strict`） | 構造/必須不変条件の欠落（frontmatter 欠落 / settings.json 不正 / hook 実行不可 等）を **failure に昇格** | 昇格対象が 1 件でもあれば 1 |
+
+strict 昇格の対象は **構造・必須不変条件**（SKILL.md の `name`/`description` frontmatter 欠落、settings.json の JSON 構造、hook 実行可能性）に限る。
+
+### `args` 警告の正当化（DoD #4 — 仕様であり昇格しない）
+
+`make validate-claude-strict` は現状の `.claude/` 構成で **exit 0（warnings 16 件）** になる。
+
+この 16 件は `commands/*.md: missing recommended fields: args` であり、**strict でも failure に昇格しない**。
+理由: `args` は **recommended（informational）field** であり、`validate_claude_frontmatter.py` 内で `record` を経由せず警告カウントに直加算されるため、strict 昇格パス（`record WARN → FAIL (strict)`）を通らない設計になっている。
+
+これは**見落としではなく仕様**である。recommended field の不足は情報提供に留め、strict が fail させるのは「構造/必須不変条件の破壊」のみとする（baseline のチェック内容は再設計しない）。
+
+### harness 回帰スイート
+
+`scripts/claude/test/harness-regression.bats` は `.claude/` harness の **不変条件**を継続的に検証する回帰スイート。
+
+```bash
+make test-harness                       # bats 経由で全 11 ケース実行
+bats scripts/claude/test/harness-regression.bats   # 直接実行
+```
+
+検証する不変条件カタログ（V6 1〜10）:
+
+1. `.claude/commands/*.md` が strict frontmatter を通過
+2. `.claude/skills/**/SKILL.md` が strict 通過（`name` == 親ディレクトリ名）
+3. `validate-claude-config.sh --strict` の e2e（現状 `.claude/` 全体が strict 通過）
+4. `make validate-claude-strict` が存在し exit 0 かつ STRICT モードで実行
+5. `settings.json` が valid JSON + `permissions`/`hooks` が配列
+6. settings.json の全 hook script が存在し実行可能
+7. 必須 hook binding（Bash PreToolUse / Write\|Edit PostToolUse）
+8. strict 昇格 false-GREEN ガード（(a) python `--dir` fixture / (b) temp `.claude/` skeleton + `cd`）
+9. prompt files に suspicious invisible Unicode 無し
+10. `terminology.md` の canonical `/<cmd>` に対応する `commands/<cmd>.md` が存在
+
+> **false-GREEN ガード**（上流 #347/#349 の学び）: strict FAIL を「exit code ≠ 0」だけで判定しない。
+> helper / python 不在の異常終了も非 0 で終わるため、それを GREEN と誤認しないよう
+> 出力マーカー（`no frontmatter` / `FAIL (strict)`）も併せて grep する。
+
+### bats 不在時の挙動
+
+`make test-harness` は既存 `verify-issue-fixture` パターンに準拠する。
+
+| 環境 | 挙動 |
+|------|------|
+| bats あり | `harness-regression.bats` を実行 |
+| bats なし・ローカル | WARN を出して skip（exit 0） |
+| bats なし・`CI=true` または `HARNESS_REQUIRE_BATS=1` | ERROR で fail（exit 1） |
+
+### strict は CI 安全網（backstop）— ローカル baseline 経路は意図的に非変更
+
+本 Issue（Wave 6-1）の strict 配線は **CI（PR マージ境界）側の安全網**であり、ローカルの proof 経路は **意図的に baseline のまま**にしている。
+
+| 経路 | モード | 理由 |
+|------|--------|------|
+| CI `docdd-validation` job | strict（`make validate-claude-strict`）+ baseline | PR マージ境界の authoritative gate |
+| ローカル `make verify-issue` の dx-docs 経路 / `/develop` `/verify` `/pr` | baseline（`make validate-claude`） | verify-issue 本体ロジックの改変は本 Issue の Out-of-scope |
+
+ローカルで strict を事前確認したい場合は **`make validate-claude-strict` を手動実行**する。
+
+> これは「見落とした gap」ではなく**設計上の意図的境界**である。ローカル proof command の universal strict 化は
+> 安全網完成後の独立改善であり、Core Track 完了をブロックしない（後続 Issue 候補・Core Track 外）。
+
+---
+
 ## 関連
 
 - [.claude/templates/issue-implementation-plan.md](../../.claude/templates/issue-implementation-plan.md) — **真の SSOT**
 - [.claude/skills/verify-input-capture/SKILL.md](../../.claude/skills/verify-input-capture/SKILL.md) — `/verify` Step 1 入力固定
 - [.claude/rules/cli-first.md](../../.claude/rules/cli-first.md) — CLI ファースト原則
 - [.claude/templates/verify-issue-result.json](../../.claude/templates/verify-issue-result.json) — `verify-issue.sh` 出力 JSON schema SSOT（5-3 契約）
-- [Makefile](../../Makefile) — `verify-issue` / `verify-issue-fixture` / `verify-issue-detect` / `shell-lint` / `shell-format-check` / `test-hooks` / `validate-claude` ターゲット
+- [Makefile](../../Makefile) — `verify-issue` / `verify-issue-fixture` / `verify-issue-detect` / `shell-lint` / `shell-format-check` / `test-hooks` / `test-harness` / `validate-claude` / `validate-claude-strict` ターゲット

--- a/scripts/claude/test/harness-regression.bats
+++ b/scripts/claude/test/harness-regression.bats
@@ -1,0 +1,225 @@
+#!/usr/bin/env bats
+# scripts/claude/test/harness-regression.bats
+#
+# Harness regression suite (Issue #67 / Wave 6-1).
+#
+# Continuously asserts the *invariants* of the .claude/ harness so that
+# silent degradation (missing frontmatter, broken settings.json, unbound
+# hooks, terminology drift) fails CI instead of slipping through.
+#
+# Invariant catalog (Issue #67 verification def V6, items 1-10):
+#   1.  commands frontmatter passes strict        (validate_claude_frontmatter.py --strict --dir .claude/commands)
+#   2.  skills   frontmatter passes strict         (name == parent dir; required in strict)
+#   3.  validate-claude-config.sh --strict e2e     (whole .claude/ passes strict)
+#   4.  make validate-claude-strict exists & exit0  (and actually runs STRICT mode)
+#   5.  settings.json valid JSON + permissions/hooks arrays
+#   6.  every hook script exists & is executable
+#   7.  required hook bindings (Bash PreToolUse / Write|Edit PostToolUse)
+#   8.  strict-promotion false-GREEN guard, 2 negative tracks:
+#         8a python --dir fixture           (frontmatter promotion)
+#         8b temp .claude/ skeleton + cd    (shell-level invariant promotion)
+#   9.  prompt files contain no suspicious invisible Unicode
+#   10. terminology.md canonical /<cmd>  <=>  .claude/commands/<cmd>.md exists
+#
+# false-GREEN guard (learned from upstream #347/#349):
+#   Never assert a strict FAIL by "exit code != 0" alone. A missing helper /
+#   absent python can also exit non-zero; that must NOT be read as GREEN.
+#   So output markers (`no frontmatter` / `FAIL (strict)`) are grep'd too
+#   (cases 8a/8b).
+#
+# SSOT: Issue #67 verification def / .claude/rules/terminology.md / .claude/rules/tdd-gate.md
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+  VALIDATOR_SH="$REPO_ROOT/scripts/claude/validate-claude-config.sh"
+  FRONTMATTER_PY="$REPO_ROOT/scripts/claude/validate_claude_frontmatter.py"
+  SETTINGS_JSON="$REPO_ROOT/.claude/settings.json"
+  TERMINOLOGY_MD="$REPO_ROOT/.claude/rules/terminology.md"
+
+  PYTHON="python3"
+  command -v python3 >/dev/null 2>&1 || PYTHON="python"
+
+  TMPDIR_BATS="$(mktemp -d)"
+}
+
+teardown() {
+  if [[ -n "${TMPDIR_BATS:-}" && -d "$TMPDIR_BATS" ]]; then
+    rm -rf "$TMPDIR_BATS"
+  fi
+}
+
+# --- 1. commands frontmatter passes strict --------------------
+
+@test "catalog 1: .claude/commands/*.md all pass --strict frontmatter" {
+  run bash -c "cd '$REPO_ROOT' && '$PYTHON' '$FRONTMATTER_PY' --strict --dir .claude/commands"
+  [ "$status" -eq 0 ]
+  # false-GREEN guard: a command file silently losing frontmatter must surface.
+  ! echo "$output" | grep -q "no frontmatter"
+}
+
+# --- 2. skills frontmatter passes strict (name == dir) --------
+
+@test "catalog 2: .claude/skills/**/SKILL.md all pass --strict (name matches dir)" {
+  run bash -c "cd '$REPO_ROOT' && '$PYTHON' '$FRONTMATTER_PY' --strict --dir .claude/skills"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q "no frontmatter (required in strict mode)"
+  ! echo "$output" | grep -q "does not match parent directory"
+}
+
+# --- 3. validate-claude-config.sh --strict e2e ---------------
+
+@test "catalog 3: validate-claude-config.sh --strict passes for current .claude/" {
+  run bash -c "cd '$REPO_ROOT' && ./scripts/claude/validate-claude-config.sh --strict"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Mode: STRICT"
+  echo "$output" | grep -q "0 failed"
+}
+
+# --- 4. make validate-claude-strict exists & runs STRICT -----
+
+@test "catalog 4: make validate-claude-strict exists, exit 0, runs STRICT" {
+  run bash -c "cd '$REPO_ROOT' && make validate-claude-strict"
+  [ "$status" -eq 0 ]
+  # false-GREEN guard: a stub target that does not actually go STRICT must fail.
+  echo "$output" | grep -q "Mode: STRICT"
+}
+
+# --- 5. settings.json valid JSON + array shapes --------------
+
+@test "catalog 5: settings.json is valid JSON with array permissions/hooks" {
+  run jq empty "$SETTINGS_JSON"
+  [ "$status" -eq 0 ]
+
+  for key in allow ask deny; do
+    run jq -r ".permissions.${key} | type" "$SETTINGS_JSON"
+    [ "$status" -eq 0 ]
+    [ "$output" = "array" ]
+  done
+
+  for evt in PreToolUse PostToolUse; do
+    run jq -r ".hooks.${evt} | type" "$SETTINGS_JSON"
+    [ "$status" -eq 0 ]
+    [ "$output" = "array" ]
+  done
+}
+
+# --- 6. hook scripts exist & are executable ------------------
+
+@test "catalog 6: every settings.json hook script exists and is executable" {
+  local scripts
+  scripts="$(jq -r '.hooks | to_entries[] | .value[] | .hooks[] | .command' "$SETTINGS_JSON")"
+  [ -n "$scripts" ]
+
+  while IFS= read -r raw; do
+    [ -z "$raw" ] && continue
+    local resolved="${raw//\$CLAUDE_PROJECT_DIR/$REPO_ROOT}"
+    [ -f "$resolved" ] || { echo "missing hook script: $resolved"; return 1; }
+    [ -x "$resolved" ] || { echo "not executable: $resolved"; return 1; }
+  done <<<"$scripts"
+}
+
+# --- 7. required hook bindings present -----------------------
+
+@test "catalog 7: Bash PreToolUse and Write|Edit PostToolUse bindings exist" {
+  run jq -r '.hooks.PreToolUse // [] | map(select(.matcher | test("Bash"))) | length' "$SETTINGS_JSON"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+
+  run jq -r '.hooks.PostToolUse // [] | map(select(.matcher | test("Write|Edit"))) | length' "$SETTINGS_JSON"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+# --- 8a strict-promotion false-GREEN guard: python --dir -----
+
+@test "catalog 8a: frontmatter promotion — baseline exit0, strict exit1 + marker" {
+  printf '# No Frontmatter Here\n\nbody only\n' >"$TMPDIR_BATS/nofm.md"
+
+  run "$PYTHON" "$FRONTMATTER_PY" --dir "$TMPDIR_BATS"
+  [ "$status" -eq 0 ]
+
+  run "$PYTHON" "$FRONTMATTER_PY" --strict --dir "$TMPDIR_BATS"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "no frontmatter"
+}
+
+# --- 8b strict-promotion false-GREEN guard: shell skeleton ---
+
+@test "catalog 8b: shell invariant promotion — baseline exit0, strict exit1 + marker" {
+  # validate-claude-config.sh pins CLAUDE_DIR=".claude" (cwd-relative, no --dir):
+  # build a minimal .claude/ skeleton and `cd` into it. settings.json = {}
+  # keeps JSON valid (baseline passes) but leaves permissions/hooks undefined
+  # -> record WARN -> promoted to FAIL (strict).
+  local sk="$TMPDIR_BATS/skel"
+  mkdir -p "$sk/.claude/commands" "$sk/.claude/rules" "$sk/.claude/skills"
+  printf '{}\n' >"$sk/.claude/settings.json"
+  printf '# skeleton\n' >"$sk/.claude/CLAUDE.md"
+  printf '# commands\n' >"$sk/.claude/commands/README.md"
+  printf '# rules\n' >"$sk/.claude/rules/README.md"
+  printf '# skills\n' >"$sk/.claude/skills/README.md"
+
+  run bash -c "cd '$sk' && '$VALIDATOR_SH'"
+  [ "$status" -eq 0 ]
+
+  run bash -c "cd '$sk' && '$VALIDATOR_SH' --strict"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "FAIL (strict)"
+}
+
+# --- 9. no suspicious invisible Unicode in prompt files ------
+
+@test "catalog 9: prompt files contain no suspicious invisible Unicode" {
+  # The forbidden codepoints are built at runtime from hex integers via
+  # chr(); the test source stays pure ASCII so it never embeds the very
+  # characters it forbids. Ranges mirror validate-claude-config.sh Check 6.
+  local checker="$TMPDIR_BATS/uni_scan.py"
+  cat >"$checker" <<'PY'
+import sys, re
+
+RANGES = [
+    (0x200B, 0x200F),  # zero-width space .. RLM
+    (0x2028, 0x202F),  # line/para sep, bidi embeddings/overrides
+    (0x2060, 0x2069),  # word joiner, invisible ops, bidi isolates
+    (0xFEFF, 0xFEFF),  # BOM / zero-width no-break space
+    (0xFFF9, 0xFFFB),  # interlinear annotation anchors
+]
+cls = "".join(chr(lo) + "-" + chr(hi) for lo, hi in RANGES)
+pattern = re.compile("[" + cls + "]")
+
+bad = 0
+for fp in sys.argv[1:]:
+    try:
+        with open(fp, encoding="utf-8", errors="replace") as fh:
+            for n, line in enumerate(fh, 1):
+                if pattern.search(line):
+                    print(f"{fp}:{n}: suspicious unicode")
+                    bad += 1
+    except OSError:
+        pass
+sys.exit(1 if bad else 0)
+PY
+
+  run bash -c "
+    cd '$REPO_ROOT' &&
+    find .claude/commands .claude/rules .claude/skills -name '*.md' -print0 2>/dev/null |
+    xargs -0 '$PYTHON' '$checker'
+  "
+  [ "$status" -eq 0 ]
+}
+
+# --- 10. terminology.md canonical /<cmd> <=> commands/<cmd>.md -
+
+@test "catalog 10: every canonical command in terminology.md has commands/<cmd>.md" {
+  [ -f "$TERMINOLOGY_MD" ]
+  local cmds
+  cmds="$(grep -oE 'commands/[a-z-]+\.md' "$TERMINOLOGY_MD" | sed 's#commands/##' | sort -u)"
+  [ -n "$cmds" ]
+
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    [ -f "$REPO_ROOT/.claude/commands/$f" ] || {
+      echo "terminology references commands/$f but file is missing"
+      return 1
+    }
+  done <<<"$cmds"
+}


### PR DESCRIPTION
## 変更内容

- **DX / harness**: `validate-claude-config.sh` の strict scaffold を CI / Makefile に正式配線し、`.claude/` harness 設定の不変条件を回帰 bats で機械検証可能にした（validator 本体は不変）。
- `Makefile`: `validate-claude-strict` / `test-harness` ターゲット + `.PHONY` を追加。bats 不在時は `verify-issue-fixture` パターン（`CI=true` / `HARNESS_REQUIRE_BATS=1` で fail、ローカルは WARN skip）。
- `docdd-starters-ci.yml`: `docdd-validation` に `validate-claude-strict`、`shell-qa` に `test-harness` step（+ setup-python / jq install）を追加。既存 step は不変。
- `harness-regression.bats`: V6 不変条件カタログ 1〜10 を 11 ケースで実装（false-GREEN ガード = exit code + 出力マーカー併用、負例 2 系統）。
- 4 SKILL.md（backend/frontend/testing-patterns / docdd-workflow）に `name`+`description` frontmatter を付与（本文不変）。strict 昇格対象だった frontmatter 欠落を解消し warnings 20→16 に改善。
- `scripts/claude/README.md`: strict 運用 / `args` 警告正当化 / 回帰スイート / bats 不在時挙動 / strict=CI 安全網境界を追記。

## テスト

- [x] `make test-harness`（PASS — 11 passed / 0 failed、catalog 1〜10）
- [x] `make validate-claude-strict`（PASS — 20 pass / 0 fail / 16 warn / exit 0）
- [x] `make validate-claude`（PASS — baseline 退行なし）
- [x] `make test-backend` / `make test-frontend`（N/A — `.claude/` harness + scripts + CI のみ。backend/frontend 非変更）
- [x] `make traceability`（N/A — DocDD 7 軸ドキュメント非該当。参考実行で exit 0）
- [x] `/verify` 軽量ブラウザヘルスチェック（N/A — UI 変更なし）
- TDD: RED（catalog 2/3/4 FAILED）→ GREEN（11 PASS）を `/tdd 67`→`/develop 67` で達成、`/verify`・`/review` で独立再現
- Codex `codex review --base main`: exit 0 / 🔴 0・🟡 0・🟢 0（"no discrete regressions introduced by the patch"）

## 関連

Closes #67
